### PR TITLE
Auditoria: refresh interval configurável + fixes (duração ao vivo, rotação de log, appdetails, doc eventemitter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ FILTER_COMPLETED_CARD_DROPS=true
 EXCLUDE_APP_IDS=[]
 USE_OWNED_GAMES=true
 MAX_GAMES_TO_IDLE=30
+# Seconds between re-running the game-selection pipeline while idling (min 10)
+REFRESH_INTERVAL_SECONDS=600
 
 # Idling backend
 # python: current steam.client backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - UX: card-drop counts parsed from badge pages so the panel and session report show real
   numbers even when the badge API has no `cards_remaining`.
 - CLI: `--config PATH` to load a custom configuration file.
+- CLI/config: `--refresh-interval-seconds` flag and `REFRESH_INTERVAL_SECONDS` setting
+  (default 600, min 10) to tune how often the selection pipeline re-runs while idling —
+  previously hard-coded to 10 minutes.
 - README: language toggle badges (English / Português-BR).
 
 ### Changed
@@ -37,6 +40,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Card-drop filtering no longer idles fully-farmed games (or misses games with real drops)
   when the web session is not genuinely authenticated against `steamcommunity.com`.
+- Terminal status panel now shows a **live, growing idle/session duration** instead of a
+  frozen `0 min`: `IdleTracker` durations fall back to the current time while a session is
+  still running (`end_time` not yet set).
+- Logging: switched the file handler to a **rotating** one (10 MB × 3 backups) so a
+  long-running idle session can no longer grow a single log file without bound.
+- Trading-card detection tolerates malformed Steam `appdetails` payloads (e.g. app
+  `2321720` returning a list where a dict is expected) instead of treating them as errors.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ All commands run through `uv` (it auto-syncs the environment).
 ./run.sh --dry-run              # print config + chosen games, no Steam contact
 ./run.sh --no-trading-cards     # skip trading-card filtering
 ./run.sh --max-games 10         # cap idled games
+./run.sh --refresh-interval-seconds 300  # re-run the selection pipeline every 5 min
 ./run-gui.sh                    # launch the Tkinter GUI (== python -m steam_idle_bot --gui)
 
 # Direct module entry (needs src/ on PYTHONPATH, which run.sh sets)
@@ -44,7 +45,7 @@ A `.githooks/pre-commit` (enable with `git config core.hooksPath .githooks`) blo
 - Config precedence (`settings_customise_sources`): init kwargs → env vars → `.env` → secrets. Custom `FlexibleEnvSettingsSource` / `FlexibleDotEnvSettingsSource` tolerantly parse list fields (`GAME_APP_IDS`, `EXCLUDE_APP_IDS` accept JSON `[570,730]` or CSV `570,730`) and the cookie map (`STEAM_WEB_COOKIES` accepts JSON object, browser-export JSON array, or `k=v; k=v`).
 - `Settings.load_from_file()` also imports a legacy `config.py` if present, mapping its UPPER_CASE names to settings fields.
 - `save_to_env_file()` serializes settings back to `.env` — used by the GUI to persist user changes.
-- CLI flags in `main.py` override loaded settings (`--max-games`, `--no-cache`, `--max-checks`, `--skip-failures`, `--keep-completed-drops`, `--no-trading-cards`).
+- CLI flags in `main.py` override loaded settings (`--max-games`, `--refresh-interval-seconds`, `--no-cache`, `--max-checks`, `--skip-failures`, `--keep-completed-drops`, `--no-trading-cards`).
 - **Web session auth**: card-drop scraping needs a `web:community` `steamLoginSecure` (see [[steam-web-cookies-community-audience]] memory). `CardDropChecker._verify_session()` probes `/badges/` (checks `g_steamID = "<id>"`) and downgrades to unauthenticated (excluding unknowns + warning) when the session is logged out — preventing the bot from idling drained games on a store-only/expired token. `AUTO_BROWSER_COOKIES=true` (default) makes `main._recover_session_via_browser()` pull a valid community session from a locally logged-in browser via `steam/browser_cookies.py` (`browser_cookie3`, import-guarded; `BROWSER_COOKIES_BROWSER=auto|chrome|firefox|...`) — self-healing as the short-lived community token rotates.
 - **Card counts**: when the badge API returns no `cards_remaining` (common once all badges are completed), `CardDropChecker._extract_drops_remaining()` parses the count from the badge page ("Jogo pode dar mais N cartas" / "N card drops remaining") into `drop_counts`; `main` feeds these into `IdleTracker` for the status panel and session report.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,6 @@ The three services are distinct: `TradingCardDetector` = *does this game have ca
 
 ## Dependency pins (don't break these)
 
-`pyproject.toml` lists only direct deps as loose floors; `uv.lock` pins exact versions (run `uv lock --upgrade` to refresh). Two non-obvious pins are load-bearing for the `steam` library:
+`pyproject.toml` lists only direct deps as loose floors; `uv.lock` pins exact versions (run `uv lock --upgrade` to refresh). Two non-obvious constraints are load-bearing for the `steam` library:
 - **`protobuf>=3.20,<4`** — the `steam[client]` extra ships protoc-generated `_pb2` modules that fail on protobuf 4+ (`Descriptors cannot be created directly`). Never bump to 4.x while on `steam` 1.4.x.
-- **`eventemitter==0.2.0`** — `steam.client` does `from eventemitter import EventEmitter`, but neither `steam` nor `gevent-eventemitter` declares the standalone `eventemitter` package; without the explicit pin, runtime imports break (tests pass anyway because they mock Steam).
+- **Do NOT add a standalone `eventemitter` package.** `steam.client` does `from eventemitter import EventEmitter`, but `steam[client]` already supplies this via `gevent-eventemitter` (a self-contained gevent-based `EventEmitter`). Installing the standalone `eventemitter` overwrites that module with an incompatible one and breaks the python backend at `SteamClient()` (`'SteamClient' object has no attribute '_listeners'`). An earlier `eventemitter==0.2.0` pin was removed for exactly this reason (commit `3f55645`); tests pass either way because they mock Steam, so a re-added pin only fails at runtime.

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,6 @@
 
 ## High Priority
 
-- Add a first-class `--refresh-interval-seconds` CLI flag and matching setting so
-  real idle verification can run at 5-minute intervals without external scripts.
-- Fix terminal idle duration display; the panel currently reports `0 min` after
-  10+ minutes of real idling.
 - Make shutdown produce a final report reliably when stopping from `run.sh` with
   Ctrl+C, not only cleanup subprocesses.
 - Add steam-utility process reconciliation: detect existing idles for target App
@@ -14,8 +10,6 @@
 
 ## Card-Drop Accuracy
 
-- Harden Steam Store `appdetails` parsing for unexpected payloads such as app
-  `2321720`, where the current parser can receive a list instead of a dict.
 - Add a structured checkpoint report mode, for example
   `--checkpoint-minutes 5 --duration-minutes 25`, writing JSON/Markdown with
   selected games, card counts, drops, refreshes, and cleanup status.

--- a/src/steam_idle_bot/config/settings.py
+++ b/src/steam_idle_bot/config/settings.py
@@ -173,6 +173,11 @@ class Settings(BaseSettings):
         le=32,
         description="Maximum number of games to idle simultaneously (Steam limit: 32)",
     )
+    refresh_interval_seconds: int = Field(
+        default=600,
+        ge=10,
+        description="Seconds between re-running the game-selection pipeline while idling",
+    )
     idling_backend: Literal["python", "steam_utility"] = Field(
         default="python",
         description="Backend used to keep Steam games idling",
@@ -353,6 +358,7 @@ class Settings(BaseSettings):
                     "EXCLUDE_APP_IDS": "exclude_app_ids",
                     "USE_OWNED_GAMES": "use_owned_games",
                     "MAX_GAMES_TO_IDLE": "max_games_to_idle",
+                    "REFRESH_INTERVAL_SECONDS": "refresh_interval_seconds",
                     "IDLING_BACKEND": "idling_backend",
                     "STEAM_UTILITY_PATH": "steam_utility_path",
                     "STEAM_API_KEY": "steam_api_key",
@@ -400,6 +406,7 @@ class Settings(BaseSettings):
             "filter_completed_card_drops": "FILTER_COMPLETED_CARD_DROPS",
             "exclude_app_ids": "EXCLUDE_APP_IDS",
             "max_games_to_idle": "MAX_GAMES_TO_IDLE",
+            "refresh_interval_seconds": "REFRESH_INTERVAL_SECONDS",
             "idling_backend": "IDLING_BACKEND",
             "steam_utility_path": "STEAM_UTILITY_PATH",
             "steam_api_key": "STEAM_API_KEY",

--- a/src/steam_idle_bot/main.py
+++ b/src/steam_idle_bot/main.py
@@ -142,7 +142,7 @@ class SteamIdleBot:
         self.logger.info("Entering main idle loop...")
         self.logger.info("Press Ctrl+C to stop")
 
-        refresh_interval = 600  # 10 minutes
+        refresh_interval = self.settings.refresh_interval_seconds
         last_refresh = time.time()
         loop_sleep_seconds = 1
         reconnect_cooldown_seconds = 10
@@ -282,7 +282,8 @@ class SteamIdleBot:
         console.print()
         console.print(table)
         console.print(summary)
-        console.print("[dim]Atualiza a cada 10 min • Ctrl+C para parar e ver o relatório[/dim]")
+        refresh_minutes = self.settings.refresh_interval_seconds / 60.0
+        console.print(f"[dim]Atualiza a cada {refresh_minutes:.0f} min • Ctrl+C para parar e ver o relatório[/dim]")
         console.print()
 
     def _capture_initial_cards(self) -> None:
@@ -533,6 +534,12 @@ Examples:
         help="Maximum number of games to idle (overrides config)",
     )
 
+    parser.add_argument(
+        "--refresh-interval-seconds",
+        type=int,
+        help="Seconds between re-running the game-selection pipeline while idling (default 600)",
+    )
+
     parser.add_argument("--config", type=str, help="Path to configuration file")
 
     parser.add_argument(
@@ -594,6 +601,9 @@ def main() -> None:
 
         if args.max_games:
             settings.max_games_to_idle = args.max_games
+
+        if args.refresh_interval_seconds is not None:
+            settings.refresh_interval_seconds = args.refresh_interval_seconds
 
         if args.no_cache:
             settings.enable_card_cache = False

--- a/src/steam_idle_bot/steam/trading_cards.py
+++ b/src/steam_idle_bot/steam/trading_cards.py
@@ -85,15 +85,18 @@ class TradingCardDetector:
 
             data = response.json()
 
-            if str(app_id) not in data or not data[str(app_id)]["success"]:
-                # Steam returns unsuccessful responses for some DLC/retired apps.
-                # Treat those as "no trading cards" and cache the result to avoid
-                # retrying the same known misses on every refresh cycle.
+            entry = data.get(str(app_id)) if isinstance(data, dict) else None
+            if not isinstance(entry, dict) or not entry.get("success"):
+                # Steam returns unsuccessful (or malformed) responses for some
+                # DLC/retired apps — e.g. app 2321720 can return a list where a
+                # dict is expected. Treat those as "no trading cards" and cache
+                # the result to avoid retrying the same known misses every cycle.
                 self._remember(app_id, False)
                 return False
 
-            categories = data[str(app_id)].get("data", {}).get("categories", [])
-            has_cards = any(cat.get("id") == self.TRADING_CARDS_CATEGORY_ID for cat in categories)
+            details = entry.get("data")
+            categories = details.get("categories", []) if isinstance(details, dict) else []
+            has_cards = any(isinstance(cat, dict) and cat.get("id") == self.TRADING_CARDS_CATEGORY_ID for cat in categories)
 
             self._remember(app_id, has_cards)
             return has_cards

--- a/src/steam_idle_bot/utils/idle_tracker.py
+++ b/src/steam_idle_bot/utils/idle_tracker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = ["GameIdleInfo", "IdleTracker"]
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -37,10 +38,16 @@ class GameIdleInfo:
 
     @property
     def idle_seconds(self) -> float:
-        """Total seconds spent idling this game."""
-        if self.start_time is None or self.end_time is None:
+        """Total seconds spent idling this game.
+
+        While the session is live (``end_time`` not yet set) this reports the
+        elapsed time up to now, so terminal panels show a growing duration
+        instead of a frozen ``0``.
+        """
+        if self.start_time is None:
             return 0.0
-        return max(0.0, self.end_time - self.start_time)
+        end = self.end_time if self.end_time is not None else time.time()
+        return max(0.0, end - self.start_time)
 
     @property
     def idle_minutes(self) -> float:
@@ -62,8 +69,6 @@ class IdleTracker:
 
     def start_session(self, game_ids: list[int], game_names: dict[int, str] | None = None) -> None:
         """Record the start of an idling session."""
-        import time
-
         self.session_start = time.time()
         if game_names:
             self.game_names.update(game_names)
@@ -82,8 +87,6 @@ class IdleTracker:
 
     def end_session(self) -> None:
         """Record the end of an idling session."""
-        import time
-
         self.session_end = time.time()
         for game in self.games.values():
             game.end_time = self.session_end
@@ -109,10 +112,15 @@ class IdleTracker:
 
     @property
     def session_seconds(self) -> float:
-        """Total session duration in seconds."""
-        if self.session_start is None or self.session_end is None:
+        """Total session duration in seconds.
+
+        Falls back to the current time while the session is still running so the
+        live status panel reflects real elapsed time instead of ``0``.
+        """
+        if self.session_start is None:
             return 0.0
-        return max(0.0, self.session_end - self.session_start)
+        end = self.session_end if self.session_end is not None else time.time()
+        return max(0.0, end - self.session_start)
 
     @property
     def session_minutes(self) -> float:

--- a/src/steam_idle_bot/utils/logger.py
+++ b/src/steam_idle_bot/utils/logger.py
@@ -3,9 +3,14 @@
 __all__ = ["SteamIdleLogger", "setup_logging"]
 
 import logging
+from logging.handlers import RotatingFileHandler
 
 from rich.console import Console
 from rich.logging import RichHandler
+
+# Cap the on-disk log so a long-running idle session can't grow it unbounded.
+_LOG_MAX_BYTES = 10 * 1024 * 1024
+_LOG_BACKUP_COUNT = 3
 
 
 class SteamIdleLogger:
@@ -41,9 +46,15 @@ class SteamIdleLogger:
             console_handler.setLevel(getattr(logging, level.upper()))
             self.logger.addHandler(console_handler)
 
-        # File handler if specified
+        # File handler if specified. Rotate so a long-running idle session does
+        # not grow a single log file without bound.
         if log_file:
-            file_handler = logging.FileHandler(log_file)
+            file_handler = RotatingFileHandler(
+                log_file,
+                maxBytes=_LOG_MAX_BYTES,
+                backupCount=_LOG_BACKUP_COUNT,
+                encoding="utf-8",
+            )
             file_handler.setFormatter(formatter)
             file_handler.setLevel(getattr(logging, level.upper()))
             self.logger.addHandler(file_handler)

--- a/tests/unit/test_idle_tracker.py
+++ b/tests/unit/test_idle_tracker.py
@@ -96,3 +96,23 @@ def test_idle_tracker_reports_unknown_drop_status_separately(tmp_path, monkeypat
     out_file = tmp_path / "reports" / "unknown.txt"
     tracker.save_report(str(out_file))
     assert out_file.exists()
+
+
+def test_idle_seconds_live_until_end_set(monkeypatch) -> None:
+    """While a session is live (end not set) duration must grow, not read 0."""
+    info = GameIdleInfo(app_id=10, start_time=100.0)
+    monkeypatch.setattr("steam_idle_bot.utils.idle_tracker.time.time", lambda: 700.0)
+    assert info.idle_seconds == 600.0
+    assert info.idle_minutes == 10.0
+    # Once end_time is recorded it freezes to the recorded span.
+    info.end_time = 400.0
+    assert info.idle_seconds == 300.0
+
+
+def test_session_seconds_live_until_end_set(monkeypatch) -> None:
+    tracker = IdleTracker()
+    monkeypatch.setattr("steam_idle_bot.utils.idle_tracker.time.time", lambda: 100.0)
+    tracker.start_session([10])
+    monkeypatch.setattr("steam_idle_bot.utils.idle_tracker.time.time", lambda: 760.0)
+    assert tracker.session_seconds == 660.0
+    assert tracker.session_minutes == 11.0

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -335,6 +335,7 @@ def test_main_applies_overrides(monkeypatch):
         config="config.py",
         no_trading_cards=True,
         max_games=4,
+        refresh_interval_seconds=120,
         no_cache=True,
         max_checks=8,
         skip_failures=True,
@@ -361,6 +362,7 @@ def test_main_applies_overrides(monkeypatch):
 
     assert settings.filter_trading_cards is False
     assert settings.max_games_to_idle == 4
+    assert settings.refresh_interval_seconds == 120
     assert settings.enable_card_cache is False
     assert settings.max_checks == 8
     assert settings.skip_failures is True

--- a/tests/unit/test_trading_cards.py
+++ b/tests/unit/test_trading_cards.py
@@ -82,6 +82,29 @@ class TestTradingCardDetector:
         assert detector._cache[123] is False
 
     @patch("steam_idle_bot.steam.trading_cards.requests.get")
+    def test_has_trading_cards_tolerates_malformed_entry(self, mock_get):
+        """Some apps (e.g. 2321720) return a list where a dict is expected."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"2321720": ["unexpected", "list"]}
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        detector = TradingCardDetector()
+        assert detector.has_trading_cards(2321720) is False
+        assert detector._cache[2321720] is False
+
+    @patch("steam_idle_bot.steam.trading_cards.requests.get")
+    def test_has_trading_cards_tolerates_non_dict_data(self, mock_get):
+        """A successful entry whose 'data' is a list must not raise."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"123": {"success": True, "data": []}}
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        detector = TradingCardDetector()
+        assert detector.has_trading_cards(123) is False
+
+    @patch("steam_idle_bot.steam.trading_cards.requests.get")
     def test_has_trading_cards_timeout(self, mock_get):
         """Test timeout handling."""
         mock_get.side_effect = TimeoutError()


### PR DESCRIPTION
## Auditoria completa + correções

Auditoria do projeto: 204 testes verdes, ruff/mypy limpos como baseline. Identificados bugs do `TODO.md`, uma contradição em `CLAUDE.md` e crescimento ilimitado de log. Corrigidos com testes.

### Correções
- **Log rotation** — `logging.FileHandler` → `RotatingFileHandler` (10 MB × 3). Causa de um `steam_card_idler.log` de ~1 GB na raiz.
- **Duração de idle "0 min"** — `IdleTracker.idle_seconds`/`session_seconds` agora caem para o tempo atual enquanto a sessão roda (`end_time` ainda não setado), então o painel mostra duração crescente em vez de `0 min` congelado.
- **`--refresh-interval-seconds` / `REFRESH_INTERVAL_SECONDS`** — intervalo do pipeline de seleção agora configurável (default 600, min 10), antes hard-coded em 10 min. Painel e help refletem o valor.
- **Parser `appdetails` robusto** — tolera payloads malformados (ex. app `2321720` retornando lista no lugar de dict) em vez de levantar erro.
- **`CLAUDE.md` corrigido** — a nota de dependência sobre `eventemitter` estava invertida: afirmava que o pin `eventemitter==0.2.0` era obrigatório, mas o commit `3f55645` o removeu porque o pacote standalone quebra o backend python (`'SteamClient' object has no attribute '_listeners'`). Doc alinhada ao `pyproject.toml`.

### Docs
- `.env.example`, `CHANGELOG.md`, `CLAUDE.md` atualizados; itens resolvidos removidos do `TODO.md`.

### Testes
- +4 testes: duração ao vivo (game + sessão), override de CLI, appdetails malformado (lista + `data` não-dict).
- **208 passam** (204 → 208), ruff ✓, mypy ✓.

### Padrões de erro recorrentes em PRs (registrados em memória)
- `__all__` antes de `from __future__ import annotations` → `SyntaxError`.
- `egg-info` gerado commitado por engano.
- Refactor de atributo privado (`_running` → `threading.Event`) sem ajustar testes.
- Pin de dependência especulativo (`eventemitter`).
