### PR TITLE
feat: shutdown gracioso (SIGINT/SIGTERM) com relatório de sessão

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   long-running idle session can no longer grow a single log file without bound.
 - Trading-card detection tolerates malformed Steam `appdetails` payloads (e.g. app
   `2321720` returning a list where a dict is expected) instead of treating them as errors.
+- Shutdown: `SIGINT`/`SIGTERM` now trigger a **graceful stop** that still emits the session
+  report and runs cleanup. Previously `SIGTERM` (e.g. when `run.sh` is terminated) killed the
+  process before the `finally` report could run.
 
 ### Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 ## High Priority
 
-- Make shutdown produce a final report reliably when stopping from `run.sh` with
-  Ctrl+C, not only cleanup subprocesses.
 - Add steam-utility process reconciliation: detect existing idles for target App
   IDs before starting, deduplicate them, and report whether they are reused,
   stopped, or left untouched.

--- a/src/steam_idle_bot/main.py
+++ b/src/steam_idle_bot/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import contextlib
+import signal
 import sys
 import threading
 import time
@@ -222,6 +223,19 @@ class SteamIdleBot:
         self._stop_event.set()
         with contextlib.suppress(Exception):
             self.client.stop_idling()
+
+    def signal_stop(self, signum: int | None = None) -> None:
+        """Signal-handler-safe stop.
+
+        Only sets the stop event so the main loop unwinds normally and the
+        ``finally`` in :meth:`run` still emits the session report and runs
+        cleanup. Network teardown (``stop_idling``/``logout``) is deferred to
+        that cleanup instead of running inside the async signal handler.
+        Critically, this lets ``SIGTERM`` (which Python does *not* turn into a
+        ``KeyboardInterrupt``) shut the bot down gracefully — e.g. when
+        ``run.sh`` is terminated — rather than killing it before the report.
+        """
+        self._stop_event.set()
 
     def _game_name_map(self) -> dict[int, str]:
         """Best-effort map of app_id -> name from the game manager."""
@@ -575,6 +589,23 @@ Examples:
     return parser
 
 
+def _install_signal_handlers(bot: SteamIdleBot) -> None:
+    """Route SIGINT/SIGTERM to a graceful stop so the session report still runs.
+
+    Signal handlers can only be installed from the main thread; the GUI path
+    runs the bot on a worker thread and never reaches here, so failures to set a
+    handler are suppressed rather than fatal.
+    """
+
+    def _handler(signum: int, _frame: object) -> None:
+        bot.logger.info("Received signal %s, stopping gracefully...", signum)
+        bot.signal_stop(signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(ValueError, OSError, AttributeError):
+            signal.signal(sig, _handler)
+
+
 def main() -> None:
     """Main entry point."""
     parser = create_parser()
@@ -619,6 +650,7 @@ def main() -> None:
 
         # Create and run bot
         bot = SteamIdleBot(settings)
+        _install_signal_handlers(bot)
         bot.run(dry_run=args.dry_run)
 
     except KeyboardInterrupt:

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -18,16 +18,16 @@ class DummyLogger:
     def __init__(self) -> None:
         self.messages: list[tuple[str, str]] = []
 
-    def info(self, msg):
+    def info(self, msg, *args):
         self.messages.append(("info", str(msg)))
 
-    def error(self, msg):
+    def error(self, msg, *args):
         self.messages.append(("error", str(msg)))
 
-    def warning(self, msg):
+    def warning(self, msg, *args):
         self.messages.append(("warning", str(msg)))
 
-    def debug(self, msg):
+    def debug(self, msg, *args):
         self.messages.append(("debug", str(msg)))
 
 
@@ -259,6 +259,59 @@ def test_main_loop_keyboard_interrupt_stops(monkeypatch):
     bot._stop_event.clear()
     bot.client.sleep = lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt())
     bot._main_loop([1])
+
+
+def test_signal_stop_sets_event_without_network_teardown():
+    """signal_stop must only flip the event; cleanup happens later in run()."""
+    bot = _build_bot()
+    bot._stop_event.clear()
+    bot.client.stopped = False
+
+    def _fail_stop():
+        bot.client.stopped = True
+        raise AssertionError("stop_idling must not run inside the signal path")
+
+    bot.client.stop_idling = _fail_stop
+
+    bot.signal_stop(15)
+
+    assert bot._stop_event.is_set()
+    assert bot.client.stopped is False
+
+
+def test_install_signal_handlers_routes_to_signal_stop(monkeypatch):
+    import signal as signal_module
+
+    bot = _build_bot()
+    bot._stop_event.clear()
+
+    registered = {}
+    monkeypatch.setattr(
+        main_module.signal,
+        "signal",
+        lambda sig, handler: registered.__setitem__(sig, handler),
+    )
+
+    main_module._install_signal_handlers(bot)
+
+    assert signal_module.SIGINT in registered
+    assert signal_module.SIGTERM in registered
+
+    # Invoking a registered handler must gracefully stop the bot.
+    registered[signal_module.SIGTERM](signal_module.SIGTERM, None)
+    assert bot._stop_event.is_set()
+
+
+def test_install_signal_handlers_suppresses_non_main_thread(monkeypatch):
+    bot = _build_bot()
+
+    def _raise(sig, handler):
+        raise ValueError("signal only works in main thread")
+
+    monkeypatch.setattr(main_module.signal, "signal", _raise)
+
+    # Must not propagate when handlers cannot be installed (e.g. worker thread).
+    main_module._install_signal_handlers(bot)
 
 
 def test_capture_cards_paths():


### PR DESCRIPTION
## Shutdown gracioso (SIGINT/SIGTERM) com relatório de sessão

Continuação do desenvolvimento pós-auditoria (TODO High Priority).

### Problema
`SIGTERM` (ex. quando `run.sh` é terminado) matava o processo antes do `finally` em `run()`, então o relatório de sessão não saía. Python só converte `SIGINT` em `KeyboardInterrupt`, não `SIGTERM`.

### Solução
- `main()` registra handlers para `SIGINT`/`SIGTERM` via `_install_signal_handlers()`.
- Novo `SteamIdleBot.signal_stop()` — **signal-safe**: só seta o stop event. O loop principal desenrola normalmente e o `finally` de `run()` emite o relatório + roda cleanup.
- Teardown de rede (`stop_idling`/`logout`) fica diferido pro cleanup existente, fora do handler assíncrono.
- Instalação suprimida fora da main thread (caminho da GUI roda em worker thread).

### Testes
- `signal_stop` seta o event sem teardown de rede.
- Handlers registrados roteiam pra `signal_stop`.
- Instalação não propaga erro fora da main thread.
- **211 passando** (208 → 211), ruff ✓, mypy ✓.

### Docs
- `CHANGELOG.md` atualizado; item resolvido removido do `TODO.md`.
