### PR TITLE
refactor: redação consistente de username nos logs (steam-utility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Security
 
+- Account-name redaction is now consistent across both idling backends: the shared
+  `utils.redaction.mask_username` helper masks the active account name in `steam_utility`
+  connection logs (previously logged in full), matching the python backend.
 - Documented why `protobuf` stays pinned `<4` (enforced by `steam[client]`), making
   advisories GHSA-8qvm-5x2c-j2w7 / GHSA-7gcm-g887-7qv7 non-actionable; accepted as
   tolerable risk (only trusted Steam-server data is deserialized).

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,5 @@
 - Add a command or CLI flag to stop only bot-owned steam-utility idles by App ID.
 - Add a preflight warning when Steam is not running or when the shell lacks the
   graphical session variables needed to start Steam.
-- Redact account names consistently in runtime logs, including steam-utility
-  connection messages.
 - Add integration tests around `run.sh` signal handling and orphan subprocess
   prevention.

--- a/src/steam_idle_bot/steam/client.py
+++ b/src/steam_idle_bot/steam/client.py
@@ -15,17 +15,16 @@ from ..utils.exceptions import (
     SteamAuthenticationError,
     SteamConnectionError,
 )
+from ..utils.redaction import mask_username
 
 logger = logging.getLogger(__name__)
 
 AuthCodeProvider = Callable[[bool, bool], str | None]
 
 
-def _mask_username(username: str | None) -> str:
-    """Mask a username for safe logging (e.g. 'ste***bot')."""
-    if not username or len(username) <= 3:
-        return "***"
-    return f"{username[:3]}***{username[-1]}"
+# Backwards-compatible alias; the canonical helper now lives in utils.redaction
+# so both idling backends mask account names consistently.
+_mask_username = mask_username
 
 
 class SteamClientWrapper:

--- a/src/steam_idle_bot/steam/steam_utility.py
+++ b/src/steam_idle_bot/steam/steam_utility.py
@@ -11,6 +11,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from ..utils.redaction import mask_username
+
 logger = logging.getLogger(__name__)
 
 
@@ -178,7 +180,7 @@ class SteamUtilityIdleClient:
         self._username = str(active_name) if active_name else None
         logger.info(
             "Connected to local Steam session%s",
-            f" for {self._username}" if self._username else "",
+            f" for {mask_username(self._username)}" if self._username else "",
         )
         return True
 

--- a/src/steam_idle_bot/utils/redaction.py
+++ b/src/steam_idle_bot/utils/redaction.py
@@ -1,0 +1,15 @@
+"""Helpers for redacting sensitive values (account names, credentials) in logs."""
+
+from __future__ import annotations
+
+__all__ = ["mask_username"]
+
+
+def mask_username(username: str | None) -> str:
+    """Mask a username for safe logging (e.g. ``'ste***bot'``).
+
+    Short or empty names collapse to ``'***'`` so no identifying prefix leaks.
+    """
+    if not username or len(username) <= 3:
+        return "***"
+    return f"{username[:3]}***{username[-1]}"

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -1,0 +1,29 @@
+"""Tests for the shared log-redaction helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from steam_idle_bot.steam.client import _mask_username
+from steam_idle_bot.utils.redaction import mask_username
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "***"),
+        ("", "***"),
+        ("abc", "***"),
+        ("ab", "***"),
+        ("steambot", "ste***t"),
+        ("bernardo", "ber***o"),
+    ],
+)
+def test_mask_username(value, expected):
+    assert mask_username(value) == expected
+
+
+def test_client_alias_points_to_shared_helper():
+    # The client backend reuses the canonical helper for consistent masking.
+    assert _mask_username is mask_username
+    assert _mask_username("steambot") == "ste***t"

--- a/tests/unit/test_steam_utility.py
+++ b/tests/unit/test_steam_utility.py
@@ -100,6 +100,18 @@ def test_login_reads_active_steam_user_from_state_report():
     assert client.username == "bot-user"
 
 
+def test_login_masks_account_name_in_logs(caplog):
+    bridge = FakeBridge()
+    client = SteamUtilityIdleClient(make_settings(), bridge=bridge)
+
+    with caplog.at_level("INFO"):
+        assert client.login() is True
+
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "bot-user" not in messages
+    assert "bot***r" in messages
+
+
 def test_login_reads_pascal_case_state_report_fields():
     bridge = FakeBridge()
     bridge.report = {


### PR DESCRIPTION
## Redação consistente de nomes de conta nos logs

Continuação pós-auditoria (TODO Operational Hygiene).

### Problema
`steam_utility` logava o nome da conta ativa por extenso na conexão (`Connected to local Steam session for <conta>`), enquanto o backend python já mascarava via `_mask_username`. Inconsistência → vazamento de PII em logs.

### Solução
- Helper extraído pra `utils/redaction.py::mask_username` (fonte única).
- Reusado nos dois backends: `SteamClientWrapper` (python) e `SteamUtilityIdleClient`.
- Log do steam-utility agora mascara (`bot***r`).
- `client._mask_username` mantido como alias compatível.

### Testes
- `test_redaction.py`: parametrizado (None/curto/normal) + alias aponta pro helper compartilhado.
- `test_steam_utility`: login mascara o nome nos logs (`caplog`).
- **219 passando** (211 → 219), ruff ✓, mypy ✓.

### Docs
- `CHANGELOG.md` (Security) atualizado; item removido do `TODO.md`.
