### PR TITLE
feat: follow-ups da auditoria — preflight, backfill de cartas, reconciliation steam-utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Shutdown: `SIGINT`/`SIGTERM` now trigger a **graceful stop** that still emits the session
   report and runs cleanup. Previously `SIGTERM` (e.g. when `run.sh` is terminated) killed the
   process before the `finally` report could run.
+- Report: final card counts are now **backfilled to 0** for games that started with known
+  cards but are no longer reported by the authenticated badge/scraper read at stop — a drained
+  badge means no remaining drops, so the session report shows a confident before/after instead
+  of `?`. Backfill only runs when an authenticated read actually returned data.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   local Steam client is running, and additionally when no graphical session
   (`DISPLAY`/`WAYLAND_DISPLAY`) is available to launch it. Never aborts; skipped for the
   `python` backend and on platforms without `/proc`.
+- steam_utility: **idle process reconciliation** before starting — existing idles for target
+  App IDs (e.g. from a previous run) are detected via `/proc`, the first is reused (adopted),
+  duplicates are stopped, and idles for non-target apps are left untouched and reported. Avoids
+  spawning duplicate idlers across restarts. Linux-only; a no-op without `/proc`.
 - Drops: persistent **no-drop cache** (`.cache/no_drop_cards.json`, per account) — games
   confirmed without remaining drops are skipped on later runs, so each run scans less.
   New settings `DROP_CACHE_PATH` / `DROP_CACHE_TTL_DAYS`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- Preflight: advisory **environment checks** for the `steam_utility` backend — warn when no
+  local Steam client is running, and additionally when no graphical session
+  (`DISPLAY`/`WAYLAND_DISPLAY`) is available to launch it. Never aborts; skipped for the
+  `python` backend and on platforms without `/proc`.
 - Drops: persistent **no-drop cache** (`.cache/no_drop_cards.json`, per account) — games
   confirmed without remaining drops are skipped on later runs, so each run scans less.
   New settings `DROP_CACHE_PATH` / `DROP_CACHE_TTL_DAYS`.

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,5 @@
 ## Operational Hygiene
 
 - Add a command or CLI flag to stop only bot-owned steam-utility idles by App ID.
-- Add a preflight warning when Steam is not running or when the shell lacks the
-  graphical session variables needed to start Steam.
 - Add integration tests around `run.sh` signal handling and orphan subprocess
   prevention.

--- a/TODO.md
+++ b/TODO.md
@@ -13,8 +13,6 @@
   selected games, card counts, drops, refreshes, and cleanup status.
 - Add delayed post-run verification, e.g. scrape immediately at stop and again
   after 30-60 seconds, because Steam badge pages can lag behind actual drops.
-- Improve final card-count capture so the session report always includes before
-  and after card counts from the authenticated scraper.
 - Investigate why Badge API returns no card-drop data for all candidates and
   document whether that is expected for this account/API endpoint.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,5 @@
 # TODO
 
-## High Priority
-
-- Add steam-utility process reconciliation: detect existing idles for target App
-  IDs before starting, deduplicate them, and report whether they are reused,
-  stopped, or left untouched.
-
 ## Card-Drop Accuracy
 
 - Add a structured checkpoint report mode, for example

--- a/src/steam_idle_bot/main.py
+++ b/src/steam_idle_bot/main.py
@@ -329,26 +329,49 @@ class SteamIdleBot:
 
     def _capture_final_cards(self) -> None:
         """Capture the final number of cards remaining for each game."""
+        # Tracks whether at least one authenticated source returned data. When it
+        # did, any idled game that started with known cards but is now absent from
+        # the response has had its badge drained, so its final count is 0.
+        authenticated_read = False
         try:
             badge_service = self.game_manager.badge_service
             if badge_service and hasattr(badge_service, "get_cards_remaining"):
                 steam_id = self.client.steam_id
                 if steam_id:
                     cards = badge_service.get_cards_remaining(steam_id)
-                    for app_id, count in cards.items():
-                        self._idle_tracker.set_cards_after(app_id, count)
-                    self.logger.info(f"Captured final card counts for {len(cards)} games")
+                    if cards is not None:
+                        authenticated_read = True
+                        for app_id, count in cards.items():
+                            self._idle_tracker.set_cards_after(app_id, count)
+                        self.logger.info(f"Captured final card counts for {len(cards)} games")
 
             # Fallback/augment: re-scrape idled games to read current counts so the
             # session report can show how many cards dropped while idling.
             if self._games_to_idle and self._steam_id and hasattr(self.game_manager, "fetch_drop_counts"):
                 counts = self.game_manager.fetch_drop_counts(self._games_to_idle, self._steam_id)
-                for app_id, count in counts.items():
-                    game = self._idle_tracker.games.get(app_id)
-                    if game is None or game.cards_after is None:
-                        self._idle_tracker.set_cards_after(app_id, count)
+                if counts is not None:
+                    authenticated_read = True
+                    for app_id, count in counts.items():
+                        game = self._idle_tracker.games.get(app_id)
+                        if game is None or game.cards_after is None:
+                            self._idle_tracker.set_cards_after(app_id, count)
         except Exception as e:
             self.logger.warning(f"Could not capture final card counts: {e}")
+
+        if authenticated_read:
+            self._backfill_drained_final_counts()
+
+    def _backfill_drained_final_counts(self) -> None:
+        """Set ``cards_after = 0`` for idled games drained during this session.
+
+        A game that started with a known card count but is no longer reported by
+        the authenticated badge/scraper read has no remaining drops, so the
+        session report can show a confident before/after instead of ``?``.
+        """
+        for app_id in self._games_to_idle:
+            game = self._idle_tracker.games.get(app_id)
+            if game is not None and game.cards_before is not None and game.cards_after is None:
+                self._idle_tracker.set_cards_after(app_id, 0)
 
     def _show_session_report(self) -> None:
         """Show the session report when bot stops."""

--- a/src/steam_idle_bot/main.py
+++ b/src/steam_idle_bot/main.py
@@ -17,6 +17,7 @@ from .steam.steam_utility import SteamUtilityIdleClient
 from .steam.trading_cards import TradingCardDetector
 from .utils.idle_tracker import IdleTracker
 from .utils.logger import setup_logging
+from .utils.preflight import preflight_warnings
 
 
 class SteamIdleBot:
@@ -91,6 +92,9 @@ class SteamIdleBot:
     def _run_normal_mode(self) -> None:
         """Run in normal mode with Steam connection."""
         self.logger.info("Starting Steam Idle Bot...")
+
+        for warning in preflight_warnings(self.settings.idling_backend):
+            self.logger.warning(warning)
 
         if not self._ensure_client_ready():
             sys.exit(1)

--- a/src/steam_idle_bot/steam/steam_utility.py
+++ b/src/steam_idle_bot/steam/steam_utility.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 __all__ = ["SteamUtilityError", "SteamUtilityBridge", "SteamUtilityIdleClient"]
 
+import contextlib
 import json
 import logging
+import os
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -14,6 +17,20 @@ from typing import Any
 from ..utils.redaction import mask_username
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_idle_app_id(args: list[str]) -> int | None:
+    """Return the app id of a steam-utility ``idle <app_id>`` invocation.
+
+    Requires a ``SteamUtility`` marker among the args so unrelated processes
+    that merely contain an ``idle`` token are not misidentified.
+    """
+    if not any("steamutility" in a.lower() for a in args):
+        return None
+    for index, arg in enumerate(args):
+        if arg == "idle" and index + 1 < len(args) and args[index + 1].isdigit():
+            return int(args[index + 1])
+    return None
 
 
 class SteamUtilityError(RuntimeError):
@@ -95,6 +112,30 @@ class SteamUtilityBridge:
             text=True,
         )
 
+    def find_idle_pids(self, proc_root: str = "/proc") -> dict[int, list[int]]:
+        """Map app_id -> sorted PIDs of running steam-utility idle processes.
+
+        Scans ``/proc`` command lines; returns an empty map where ``/proc`` is
+        unavailable (e.g. non-Linux), making reconciliation a no-op there.
+        """
+        root = Path(proc_root)
+        if not root.is_dir():
+            return {}
+
+        found: dict[int, list[int]] = {}
+        for entry in root.iterdir():
+            if not entry.name.isdigit():
+                continue
+            try:
+                raw = (entry / "cmdline").read_bytes()
+            except OSError:
+                continue
+            args = [part.decode("utf-8", "replace") for part in raw.split(b"\x00") if part]
+            app_id = _extract_idle_app_id(args)
+            if app_id is not None:
+                found.setdefault(app_id, []).append(int(entry.name))
+        return {app_id: sorted(pids) for app_id, pids in found.items()}
+
     def _resolve_project_root(self) -> Path:
         for candidate in self._candidate_paths():
             root = self._normalize_candidate(candidate)
@@ -149,6 +190,9 @@ class SteamUtilityIdleClient:
         self._steam_id: str | None = None
         self._username: str | None = None
         self._processes: dict[int, subprocess.Popen[str]] = {}
+        # External idle PIDs adopted from a previous run instead of re-spawned.
+        self._adopted_pids: dict[int, int] = {}
+        self._reconciled = False
 
     def initialize(self) -> bool:
         """Resolve the steam-utility repository before starting."""
@@ -184,8 +228,65 @@ class SteamUtilityIdleClient:
         )
         return True
 
+    def reconcile_existing_idles(
+        self,
+        game_ids: list[int],
+        *,
+        proc_root: str = "/proc",
+    ) -> dict[str, list[tuple[int, int]]]:
+        """Adopt or deduplicate pre-existing steam-utility idles before starting.
+
+        For each target app id already being idled by an external process (e.g. a
+        previous bot run), the first PID is **reused** (adopted) and any further
+        duplicates are **stopped**. Idles for non-target apps are **left
+        untouched** and only reported. Returns a report keyed by
+        ``reused``/``stopped``/``untouched`` mapping to ``(app_id, pid)`` tuples.
+        """
+        targets: list[int] = []
+        seen: set[int] = set()
+        for app_id in game_ids:
+            if app_id not in seen:
+                seen.add(app_id)
+                targets.append(app_id)
+
+        existing = self.bridge.find_idle_pids(proc_root)
+        own = {process.pid for process in self._processes.values()}
+        report: dict[str, list[tuple[int, int]]] = {"reused": [], "stopped": [], "untouched": []}
+
+        for app_id in targets:
+            pids = [pid for pid in existing.get(app_id, []) if pid not in own]
+            if not pids:
+                continue
+            keep = pids[0]
+            self._adopted_pids[app_id] = keep
+            report["reused"].append((app_id, keep))
+            for duplicate in pids[1:]:
+                self._stop_pid(duplicate)
+                report["stopped"].append((app_id, duplicate))
+
+        for app_id, pids in existing.items():
+            if app_id in seen:
+                continue
+            for pid in pids:
+                if pid not in own:
+                    report["untouched"].append((app_id, pid))
+
+        if any(report.values()):
+            logger.info(
+                "Reconciled existing steam-utility idles: %d reused, %d duplicates stopped, %d left untouched",
+                len(report["reused"]),
+                len(report["stopped"]),
+                len(report["untouched"]),
+            )
+        return report
+
     def start_idling(self, game_ids: list[int]) -> bool:
         """Start or refresh long-running native idling processes."""
+        if not self._reconciled:
+            self._reconciled = True
+            with contextlib.suppress(Exception):
+                self.reconcile_existing_idles(game_ids)
+
         desired = []
         seen: set[int] = set()
         for game_id in game_ids:
@@ -198,9 +299,17 @@ class SteamUtilityIdleClient:
         for app_id in list(self._processes):
             if app_id not in desired_set:
                 self._stop_process(app_id)
+        for app_id in list(self._adopted_pids):
+            if app_id not in desired_set:
+                del self._adopted_pids[app_id]
 
         started_all = True
         for app_id in desired:
+            adopted = self._adopted_pids.get(app_id)
+            if adopted is not None and self._pid_alive(adopted):
+                # An external idle from a previous run is already covering this app.
+                continue
+
             process = self._processes.get(app_id)
             if process is not None and process.poll() is None:
                 continue
@@ -232,9 +341,10 @@ class SteamUtilityIdleClient:
         return started_all and self.is_connected()
 
     def stop_idling(self) -> bool:
-        """Stop all native idling processes."""
+        """Stop all native idling processes (adopted external idles are left running)."""
         for app_id in list(self._processes):
             self._stop_process(app_id)
+        self._adopted_pids.clear()
         return True
 
     def refresh_games(self, game_ids: list[int]) -> bool:
@@ -242,10 +352,23 @@ class SteamUtilityIdleClient:
         return self.start_idling(game_ids)
 
     def is_connected(self) -> bool:
-        """Consider the backend healthy while all managed processes are alive."""
-        if not self._processes:
+        """Healthy while every managed process and adopted external idle is alive."""
+        if not self._processes and not self._adopted_pids:
             return False
-        return all(process.poll() is None for process in self._processes.values())
+        managed_ok = all(process.poll() is None for process in self._processes.values())
+        adopted_ok = all(self._pid_alive(pid) for pid in self._adopted_pids.values())
+        return managed_ok and adopted_ok
+
+    @staticmethod
+    def _pid_alive(pid: int, proc_root: str = "/proc") -> bool:
+        """Return True while the PID is present (a live process)."""
+        return Path(proc_root, str(pid)).exists()
+
+    def _stop_pid(self, pid: int) -> None:
+        """Terminate an external idle PID we did not spawn ourselves."""
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.kill(pid, signal.SIGTERM)
+        logger.info("Stopped duplicate steam-utility idle PID %s", pid)
 
     def reconnect(self) -> bool:
         """Re-read the local Steam state and let the caller restart idling."""

--- a/src/steam_idle_bot/utils/preflight.py
+++ b/src/steam_idle_bot/utils/preflight.py
@@ -1,0 +1,83 @@
+"""Best-effort environment preflight checks emitted before idling starts.
+
+These are advisory only: they never abort the run. They exist because the
+``steam_utility`` backend drives a *locally running* Steam client and, when Steam
+is closed, needs a graphical session to launch it. The default ``python`` backend
+connects to Steam's network directly and does not care, so the Steam-process
+warning is scoped to the ``steam_utility`` backend to avoid false positives.
+"""
+
+from __future__ import annotations
+
+__all__ = ["has_graphical_session", "is_steam_running", "preflight_warnings"]
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+_GRAPHICAL_ENV_VARS = ("DISPLAY", "WAYLAND_DISPLAY")
+
+
+def has_graphical_session(env: Mapping[str, str] | None = None) -> bool:
+    """Return True when a graphical session variable is set (X11 or Wayland)."""
+    env = os.environ if env is None else env
+    return any(env.get(var) for var in _GRAPHICAL_ENV_VARS)
+
+
+def is_steam_running(proc_root: str = "/proc") -> bool | None:
+    """Detect a running Steam client by scanning ``/proc``.
+
+    Returns ``True``/``False`` on Linux, or ``None`` when detection is not
+    possible (no ``/proc``, e.g. non-Linux platforms) so callers can stay quiet
+    instead of emitting a misleading warning.
+    """
+    root = Path(proc_root)
+    if not root.is_dir():
+        return None
+
+    found_any = False
+    for entry in root.iterdir():
+        if not entry.name.isdigit():
+            continue
+        comm = entry / "comm"
+        try:
+            name = comm.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            continue
+        found_any = True
+        # Steam's main process reports as "steam"; helper processes use names
+        # like "steamwebhelper" — match the primary client only.
+        if name == "steam":
+            return True
+
+    # If we could read at least one comm entry, absence is a real negative.
+    return False if found_any else None
+
+
+def preflight_warnings(
+    backend: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    proc_root: str = "/proc",
+) -> list[str]:
+    """Build advisory warning messages for the given idling backend.
+
+    Only the ``steam_utility`` backend depends on a local Steam client, so the
+    checks are skipped entirely for other backends.
+    """
+    if backend != "steam_utility":
+        return []
+
+    warnings: list[str] = []
+    running = is_steam_running(proc_root)
+    if running is False:
+        warnings.append(
+            "Steam does not appear to be running; the steam_utility backend needs "
+            "a logged-in Steam client to idle games."
+        )
+        if not has_graphical_session(env):
+            warnings.append(
+                "No graphical session detected (DISPLAY/WAYLAND_DISPLAY unset); "
+                "Steam cannot be launched automatically from this shell."
+            )
+    return warnings

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -261,6 +261,39 @@ def test_main_loop_keyboard_interrupt_stops(monkeypatch):
     bot._main_loop([1])
 
 
+def test_capture_final_backfills_drained_games_to_zero():
+    """A game with known cards but absent from the final read drained to 0."""
+    bot = _build_bot()
+    bot._steam_id = "123"
+    bot._games_to_idle = [10, 20]
+    # Final authenticated read only reports game 10; game 20 is now complete.
+    bot.game_manager.badge_service = DummyBadgeService({10: 2})
+    bot._idle_tracker.start_session([10, 20])
+    bot._idle_tracker.set_cards_before(10, 5)
+    bot._idle_tracker.set_cards_before(20, 3)
+
+    bot._capture_final_cards()
+
+    assert bot._idle_tracker.games[10].cards_after == 2
+    assert bot._idle_tracker.games[20].cards_after == 0
+    # Both games now have a confident before/after, none left "unknown".
+    assert bot._idle_tracker.games_with_unknown_drops == []
+
+
+def test_capture_final_no_backfill_when_read_fails():
+    """If no authenticated source returned data, don't fabricate zeros."""
+    bot = _build_bot()
+    bot._steam_id = "123"
+    bot._games_to_idle = [10, 20]
+    bot.game_manager.badge_service = DummyBadgeService(exc=RuntimeError("logged out"))
+    bot._idle_tracker.start_session([10, 20])
+    bot._idle_tracker.set_cards_before(10, 5)
+
+    bot._capture_final_cards()
+
+    assert bot._idle_tracker.games[10].cards_after is None
+
+
 def test_signal_stop_sets_event_without_network_teardown():
     """signal_stop must only flip the event; cleanup happens later in run()."""
     bot = _build_bot()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,0 +1,72 @@
+"""Tests for advisory environment preflight checks."""
+
+from __future__ import annotations
+
+from steam_idle_bot.utils.preflight import (
+    has_graphical_session,
+    is_steam_running,
+    preflight_warnings,
+)
+
+
+def _make_proc(tmp_path, processes):
+    """Build a fake /proc tree: processes maps pid -> comm name."""
+    for pid, comm in processes.items():
+        d = tmp_path / str(pid)
+        d.mkdir()
+        (d / "comm").write_text(f"{comm}\n", encoding="utf-8")
+    # A non-numeric entry should be ignored by the scanner.
+    (tmp_path / "self").mkdir()
+    return str(tmp_path)
+
+
+def test_has_graphical_session():
+    assert has_graphical_session({"DISPLAY": ":0"}) is True
+    assert has_graphical_session({"WAYLAND_DISPLAY": "wayland-0"}) is True
+    assert has_graphical_session({}) is False
+    assert has_graphical_session({"DISPLAY": ""}) is False
+
+
+def test_is_steam_running_detects_steam(tmp_path):
+    proc = _make_proc(tmp_path, {10: "steam", 11: "steamwebhelper"})
+    assert is_steam_running(proc) is True
+
+
+def test_is_steam_running_negative(tmp_path):
+    proc = _make_proc(tmp_path, {10: "bash", 11: "steamwebhelper"})
+    assert is_steam_running(proc) is False
+
+
+def test_is_steam_running_unknown_without_proc(tmp_path):
+    assert is_steam_running(str(tmp_path / "missing")) is None
+
+
+def test_preflight_skips_non_steam_utility_backend(tmp_path):
+    proc = _make_proc(tmp_path, {10: "bash"})
+    assert preflight_warnings("python", env={}, proc_root=proc) == []
+
+
+def test_preflight_warns_when_steam_down_and_headless(tmp_path):
+    proc = _make_proc(tmp_path, {10: "bash"})
+    warnings = preflight_warnings("steam_utility", env={}, proc_root=proc)
+    assert len(warnings) == 2
+    assert "Steam does not appear to be running" in warnings[0]
+    assert "No graphical session" in warnings[1]
+
+
+def test_preflight_warns_steam_down_with_graphical_session(tmp_path):
+    proc = _make_proc(tmp_path, {10: "bash"})
+    warnings = preflight_warnings("steam_utility", env={"DISPLAY": ":0"}, proc_root=proc)
+    assert len(warnings) == 1
+    assert "Steam does not appear to be running" in warnings[0]
+
+
+def test_preflight_silent_when_steam_running(tmp_path):
+    proc = _make_proc(tmp_path, {10: "steam"})
+    assert preflight_warnings("steam_utility", env={}, proc_root=proc) == []
+
+
+def test_preflight_silent_when_detection_unknown(tmp_path):
+    # No /proc available (e.g. non-Linux): stay quiet rather than warn falsely.
+    missing = str(tmp_path / "missing")
+    assert preflight_warnings("steam_utility", env={}, proc_root=missing) == []

--- a/tests/unit/test_steam_utility.py
+++ b/tests/unit/test_steam_utility.py
@@ -23,10 +23,11 @@ def make_settings(**overrides) -> Settings:
 
 
 class FakeProcess:
-    def __init__(self, *, running: bool = True, stdout: str = "", stderr: str = ""):
+    def __init__(self, *, running: bool = True, stdout: str = "", stderr: str = "", pid: int = 1000):
         self.running = running
         self.stdout_text = stdout
         self.stderr_text = stderr
+        self.pid = pid
         self.terminated = False
         self.killed = False
 
@@ -59,6 +60,11 @@ class FakeBridge:
         }
         self.spawned: list[int] = []
         self.processes: dict[int, FakeProcess] = {}
+        self.idle_pids: dict[int, list[int]] = {}
+
+    def find_idle_pids(self, proc_root="/proc"):
+        del proc_root
+        return {app_id: list(pids) for app_id, pids in self.idle_pids.items()}
 
     def get_state_report(self):
         return dict(self.report)
@@ -172,3 +178,70 @@ def test_get_web_session_uses_configured_cookies(monkeypatch):
 
     session = client.get_web_session(cookies={"sessionid": "abc"})
     assert session == {"cookies": {"sessionid": "abc"}}
+
+
+def test_extract_idle_app_id_requires_marker():
+    from steam_idle_bot.steam.steam_utility import _extract_idle_app_id
+
+    assert _extract_idle_app_id(["dotnet", "run", "SteamUtility.Cli", "idle", "570"]) == 570
+    # Missing steam-utility marker -> ignored.
+    assert _extract_idle_app_id(["python", "idle", "570"]) is None
+    # 'idle' present but no numeric app id following.
+    assert _extract_idle_app_id(["SteamUtility.Cli", "idle"]) is None
+
+
+def test_find_idle_pids_scans_proc(tmp_path):
+    from steam_idle_bot.steam.steam_utility import SteamUtilityBridge
+
+    def write_cmdline(pid, args):
+        d = tmp_path / str(pid)
+        d.mkdir()
+        (d / "cmdline").write_bytes(b"\x00".join(a.encode() for a in args) + b"\x00")
+
+    write_cmdline(111, ["dotnet", "run", "--project", "x/SteamUtility.Cli", "--", "idle", "570"])
+    write_cmdline(112, ["dotnet", "run", "--project", "x/SteamUtility.Cli", "--", "idle", "570"])
+    write_cmdline(222, ["dotnet", "run", "--project", "x/SteamUtility.Cli", "--", "idle", "730"])
+    write_cmdline(333, ["bash"])  # unrelated
+    (tmp_path / "kernel").mkdir()  # non-numeric entry ignored
+
+    bridge = SteamUtilityBridge(configured_path=None)
+    pids = bridge.find_idle_pids(str(tmp_path))
+    assert pids == {570: [111, 112], 730: [222]}
+
+
+def test_find_idle_pids_returns_empty_without_proc(tmp_path):
+    from steam_idle_bot.steam.steam_utility import SteamUtilityBridge
+
+    bridge = SteamUtilityBridge(configured_path=None)
+    assert bridge.find_idle_pids(str(tmp_path / "nope")) == {}
+
+
+def test_reconcile_reuses_first_stops_dupes_and_reports_untouched(monkeypatch):
+    bridge = FakeBridge()
+    bridge.idle_pids = {570: [111, 112], 730: [222]}
+    client = SteamUtilityIdleClient(make_settings(), bridge=bridge)
+
+    stopped: list[int] = []
+    monkeypatch.setattr(client, "_stop_pid", stopped.append)
+
+    report = client.reconcile_existing_idles([570, 570])  # duplicate target collapses
+
+    assert report["reused"] == [(570, 111)]
+    assert report["stopped"] == [(570, 112)]
+    assert report["untouched"] == [(730, 222)]
+    assert client._adopted_pids == {570: 111}
+    assert stopped == [112]
+
+
+def test_start_idling_skips_spawn_for_adopted_alive_pid(monkeypatch):
+    bridge = FakeBridge()
+    bridge.idle_pids = {570: [111]}
+    client = SteamUtilityIdleClient(make_settings(), bridge=bridge)
+
+    monkeypatch.setattr(SteamUtilityIdleClient, "_pid_alive", staticmethod(lambda pid, proc_root="/proc": True))
+
+    assert client.start_idling([570]) is True
+    # External idle adopted -> no new process spawned.
+    assert bridge.spawned == []
+    assert client._adopted_pids == {570: 111}
+    assert client.is_connected() is True


### PR DESCRIPTION
## Follow-ups da auditoria — 3 itens do TODO

Continuação do desenvolvimento. Três itens do TODO, cada um em seu commit, todos com testes.

### 1. Preflight warnings (`steam_utility`)
Avisos **não-fatais** antes de idlar quando o backend é `steam_utility`: Steam client não está rodando, e/ou falta sessão gráfica (`DISPLAY`/`WAYLAND_DISPLAY`) pra lançá-lo. Detecção via `/proc`; `None` (silêncio) onde não há `/proc`. Backend `python` é isento. Novo `utils/preflight.py`.

### 2. Backfill de cartas finais no relatório
Jogo que começou com cartas conhecidas mas sumiu da leitura autenticada final → badge drenado → `cards_after = 0` (antes ficava `?`/unknown). Só roda quando uma leitura autenticada de fato retornou dados — scrape falho/deslogado nunca fabrica zeros.

### 3. Reconciliation de idles steam-utility
No primeiro `start_idling`, varre `/proc` por idles steam-utility (`dotnet ... idle <app_id>`) já rodando. Por App ID alvo: **reusa** o primeiro PID (adota), **para** duplicatas (dedup), **deixa intactos** idles de apps não-alvo — tudo num report. PIDs adotados contam pra `is_connected` e pulam spawn → sem idlers duplicados entre restarts. Linux-only; no-op sem `/proc`.

### Qualidade
- **235 passando** (219 → 235, +16 testes: preflight, backfill, reconciliation), ruff ✓, mypy ✓.
- `CHANGELOG.md` atualizado; 3 itens removidos do `TODO.md`.

### TODO restante (design-heavy, não incluído)
checkpoint report mode, delayed post-run verification, investigar Badge API sem dados, stop-by-appid, testes de integração do run.sh.
