### PR TITLE
docs: README novo (banner + schemas SVG) e backlog scrum completo

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,13 +2,10 @@
 name: Deploy docs to Pages
 
 on:
-  # Deploy docs on pushes to main that touch docs/ or workflow itself
+  # Deploy docs on pushes to main that touch docs/ or the workflow itself.
+  # Pages deployment targets the protected `github-pages` environment, which only
+  # permits `main`, so this must NOT run on pull requests (it would fail instantly).
   push:
-    branches: ["main"]
-    paths:
-      - "docs/**"
-      - ".github/workflows/static.yml"
-  pull_request:
     branches: ["main"]
     paths:
       - "docs/**"

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,138 @@
+# 📋 Product Backlog & Roadmap
+
+Living, scrum-style backlog for **Steam Idle Bot**. Tracks shipped work, the prioritized
+queue, known defects, and risks. Source of truth for "what's next"; narrative history lives
+in [`CHANGELOG.md`](CHANGELOG.md).
+
+---
+
+## Legend
+
+| Field | Values |
+|-------|--------|
+| **Status** | ✅ Done · 🟡 In progress · ⬜ Todo · 🧊 Icebox |
+| **Type** | ✨ Feature · 🐛 Bug · 🧱 Tech-debt · 📚 Docs · 🔐 Security · 🧪 Test |
+| **Impact** | 🟥 High · 🟧 Medium · 🟩 Low (user/operational value) |
+| **Effort** | `S` ≤½ day · `M` 1–3 days · `L` > 3 days |
+| **Priority** | `P0` now · `P1` next · `P2` soon · `P3` later — derived from impact ÷ effort |
+
+**Definition of Done:** code + tests green (`ruff` · `mypy` · `pytest` across 3.12–3.14),
+docs/CHANGELOG updated, no committed secrets/artifacts, reviewed & merged to `main`.
+
+**Cadence:** ~1-week sprints. Each closed sprint ships as a PR; backlog re-groomed at close.
+
+---
+
+## ✅ Shipped (sprints 1–5)
+
+> Delivered in PRs [#30](https://github.com/bernardopg/steam-idler-python/pull/30)–[#34](https://github.com/bernardopg/steam-idler-python/pull/34). Test suite grew 204 → 242.
+
+### Sprint 1 — Audit & hardening · PR #30
+- [x] 🐛 🟥 Rotate the log file (`RotatingFileHandler`, 10 MB × 3) — fixes unbounded 1 GB log growth
+- [x] 🐛 🟥 Live idle/session duration in the panel (was frozen at `0 min`)
+- [x] ✨ 🟧 Configurable `--refresh-interval-seconds` / `REFRESH_INTERVAL_SECONDS`
+- [x] 🐛 🟧 Tolerate malformed Steam `appdetails` payloads (e.g. app `2321720`)
+- [x] 📚 🟥 Correct inverted `eventemitter` dependency note in `CLAUDE.md`
+
+### Sprint 2 — Graceful shutdown · PR #31
+- [x] 🐛 🟥 `SIGINT`/`SIGTERM` graceful stop that still emits the session report
+
+### Sprint 3 — Privacy · PR #32
+- [x] 🔐 🟧 Consistent account-name redaction across both backends (`utils.redaction`)
+
+### Sprint 4 — Follow-ups · PR #33
+- [x] ✨ 🟧 Preflight warnings (Steam not running / no graphical session) for `steam_utility`
+- [x] 🐛 🟧 Backfill drained final card counts to `0` in the session report
+- [x] ✨ 🟧 steam-utility idle reconciliation (reuse / dedup / report via `/proc`)
+
+### Sprint 5 — Backlog close-out · PR #34
+- [x] ✨ 🟧 Checkpoint report mode (`--checkpoint-minutes` → JSON + Markdown) + `--duration-minutes`
+- [x] ✨ 🟩 Delayed post-run verification (`--post-run-verify-seconds`)
+- [x] ✨ 🟩 `--stop-app-ids` maintenance mode
+- [x] 🧪 🟧 run.sh signal-forwarding integration tests
+- [x] 📚 🟩 Document expected empty Badge-API card-drop responses
+
+---
+
+## 🎯 Product backlog (prioritized)
+
+### EPIC A — Reliability & resilience
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| A1 | 🧪 | Raise coverage on `steam_utility.py` (56%) and `client.py` (79%) | 🟧 | M | P1 | ⬜ |
+| A2 | ✨ | Exponential backoff + jitter on reconnect storms | 🟧 | S | P2 | ⬜ |
+| A3 | 🧱 | Structured health metrics (uptime, reconnects, drops/hr) exposed to the panel | 🟩 | M | P3 | ⬜ |
+| A4 | 🐛 | Detect & recover from a silently-killed steam-utility child mid-session | 🟧 | M | P2 | ⬜ |
+
+### EPIC B — Card-drop accuracy
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| B1 | ✨ | Honor Steam's weekly 3-drop / playtime gate in the planner | 🟥 | L | P1 | ⬜ |
+| B2 | ✨ | Cross-check badge-API vs scraper counts; warn on divergence | 🟧 | M | P2 | ⬜ |
+| B3 | 🧱 | Cache TTL auto-tuning from observed drop cadence | 🟩 | M | P3 | 🧊 |
+
+### EPIC C — Backends & idling
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| C1 | ✨ | Multi-account / account-rotation support | 🟥 | L | P2 | 🧊 |
+| C2 | ✨ | Windows-native steam-utility process detection (no `/proc`) | 🟧 | M | P2 | ⬜ |
+| C3 | 🧱 | Formalize the backend `Protocol` and add a conformance test suite | 🟧 | S | P1 | ⬜ |
+
+### EPIC D — UX (terminal & GUI)
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| D1 | 🧪 | GUI test coverage (currently 11%) — extract logic from Tkinter | 🟧 | L | P1 | ⬜ |
+| D2 | ✨ | Live-updating terminal panel (in-place refresh, not reprint) | 🟩 | M | P3 | ⬜ |
+| D3 | ✨ | GUI: per-game drop progress bars + ETA | 🟩 | M | P3 | 🧊 |
+
+### EPIC E — Observability & reporting
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| E1 | ✨ | HTML/Markdown session summary with charts | 🟩 | M | P3 | ⬜ |
+| E2 | ✨ | Prometheus/JSON metrics endpoint for long-running hosts | 🟩 | M | P3 | 🧊 |
+
+### EPIC F — Packaging & distribution
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| F1 | ✨ | Publish to PyPI (`pipx install steam-idle-bot`) | 🟥 | M | P1 | ⬜ |
+| F2 | ✨ | Official Docker image + compose for headless 24/7 idling | 🟧 | M | P2 | ⬜ |
+| F3 | 📚 | Release automation (tagged builds, changelog extraction) | 🟧 | S | P2 | ⬜ |
+
+### EPIC G — Quality & testing
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| G1 | 🧪 | Enforce a coverage floor in CI (e.g. fail < 80%) | 🟧 | S | P1 | ⬜ |
+| G2 | 🧪 | Add `pytest-timeout` to kill hung tests deterministically | 🟧 | S | P1 | ⬜ |
+| G3 | 🧱 | Adopt `ruff format --check` as a CI gate | 🟩 | S | P2 | ⬜ |
+
+### EPIC H — Security & privacy
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| H1 | 🔐 | Optional OS-keyring credential storage (drop plaintext `.env`) | 🟥 | M | P1 | ⬜ |
+| H2 | 🔐 | Redact cookies/tokens in `DetailedLogger` JSON dumps | 🟧 | S | P1 | ⬜ |
+| H3 | 🔐 | Document & track the accepted `protobuf<4` advisory exceptions | 🟩 | S | P2 | ✅ |
+
+### EPIC I — Documentation
+| ID | Type | Item | Impact | Effort | Priority | Status |
+|----|------|------|:------:|:------:|:--------:|:------:|
+| I1 | 📚 | Architecture deep-dive page linked from the README diagrams | 🟧 | S | P2 | ⬜ |
+| I2 | 📚 | Troubleshooting matrix (auth failures, 429s, no drops) | 🟧 | S | P1 | ⬜ |
+| I3 | 📚 | Animated demo (asciinema/GIF) in the README | 🟩 | S | P3 | ⬜ |
+
+---
+
+## 🐛 Known defects / risks
+
+| ID | Severity | Description | Mitigation | Status |
+|----|:--------:|-------------|-----------|:------:|
+| R1 | 🟧 | steam-utility reconciliation is Linux-only (`/proc`) | No-op elsewhere; tracked as C2 | ⬜ |
+| R2 | 🟩 | `protobuf<4` pin blocks GHSA-8qvm-5x2c-j2w7 / GHSA-7gcm-g887-7qv7 | Accepted: only trusted Steam data deserialized | ✅ |
+| R3 | 🟧 | Card-drop scraping depends on a short-lived community cookie | Auto browser-cookie recovery; session verify | ✅ |
+| R4 | 🟩 | GUI is largely untested (11% coverage) | Tracked as D1 | ⬜ |
+
+---
+
+## 📌 Next sprint candidate (groomed)
+
+Top of queue by impact ÷ effort: **F1** (PyPI), **G1+G2** (coverage floor + test timeout),
+**I2** (troubleshooting matrix), **H2** (redact logger dumps), **C3** (backend conformance tests).

--- a/README.md
+++ b/README.md
@@ -1,78 +1,149 @@
-# 🎴 Steam Idle Bot
+<p align="center">
+  <img src="docs/assets/banner.svg" alt="Steam Idle Bot — farm playtime and trading-card drops on autopilot" width="100%">
+</p>
 
-[![English](https://img.shields.io/badge/lang-English-blue)](docs/en/README.md)
-[![Português (BR)](https://img.shields.io/badge/idioma-Portugu%C3%AAs%20(BR)-green)](docs/pt-br/README.md)
-[![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/bernardopg/steam-idler-python.svg?style=social)](https://github.com/bernardopg/steam-idler-python/stargazers)
+<p align="center">
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12%2B-66c0f4.svg" alt="Python 3.12+"></a>
+  <a href="https://github.com/astral-sh/uv"><img src="https://img.shields.io/badge/managed%20by-uv-a3cf06.svg" alt="uv-managed"></a>
+  <img src="https://img.shields.io/badge/tests-242%20passing-2ea043.svg" alt="242 tests passing">
+  <img src="https://img.shields.io/badge/typed-mypy%20clean-66c0f4.svg" alt="mypy clean">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-c7d5e0.svg" alt="MIT license"></a>
+  <a href="docs/en/README.md"><img src="https://img.shields.io/badge/docs-EN-blue" alt="English docs"></a>
+  <a href="docs/pt-br/README.md"><img src="https://img.shields.io/badge/docs-PT--BR-green" alt="Docs em Português"></a>
+</p>
 
-> **EN** — Farm Steam playtime and trading-card drops on autopilot. It syncs your library, idles only the games that still have cards to drop, and remembers what's already finished so every run gets faster. Clean terminal dashboard, optional GUI, two idling backends.
->
-> **PT-BR** — Farme tempo de jogo e drops de cartas Steam no automático. Sincroniza sua biblioteca, faz idle só dos jogos que ainda têm cartas para dropar e lembra do que já acabou, deixando cada execução mais rápida. Dashboard limpo no terminal, GUI opcional e dois backends de idle.
-
----
-
-## 📖 Documentation / Documentação
-
-|                | 🇺🇸 English | 🇧🇷 Português (BR) |
-| -------------- | ----------- | ------------------ |
-| Full guide     | [README](docs/en/README.md) | [README](docs/pt-br/README.md) |
-| Command sheet  | [USAGE](docs/en/USAGE.md)   | [USAGE](docs/pt-br/USAGE.md)   |
-| Security       | [SECURITY](docs/en/SECURITY.md) | [SECURITY](docs/pt-br/SECURITY.md) |
+> **Farm Steam playtime and trading-card drops on autopilot.** Steam Idle Bot syncs your
+> library, idles **only** the games that still have cards to drop, and remembers what's
+> already finished — so every run scans less and starts faster. Live terminal dashboard,
+> optional desktop GUI, two interchangeable idling backends with automatic fallback.
 
 ---
 
-## ✨ Highlights
+## Why it's different
 
-- 🎴 **Drops only where it matters** — detects which games have trading cards and how many drops remain, idling just those.
-- 🧠 **Learns over time** — a persistent cache records games that are fully farmed and skips them forever, so each run scans less and starts faster.
-- 🔐 **Accurate by design** — verifies the Steam web session is genuinely logged in before trusting it, and can auto-recover a valid session from a browser you're signed into.
-- 🖥️ **Readable output** — a live terminal panel shows game names, cards remaining, and idle time; a full session report at the end.
-- 🔁 **Two backends** — the built-in Python client (Steam Guard / 2FA) or delegation to a local `steam-utility` install, with automatic fallback.
-- ⚡ **Modern tooling** — `uv`-managed, reproducible, fully tested.
+Most idlers blindly run every game forever. Steam Idle Bot is **accurate and self-pruning**:
+
+| | |
+|---|---|
+| 🎴 **Drops only where it matters** | Detects which games have trading cards and how many drops remain — idles just those, never wasting a slot on a drained game. |
+| 🧠 **Learns over time** | A persistent no-drop cache records fully-farmed games and skips them forever. Each run scans less. |
+| 🔐 **Accurate by design** | Verifies the Steam web session is *genuinely* logged in before trusting it; auto-recovers a valid session from a browser you're signed into. |
+| 🖥️ **Readable output** | Live panel of game names, cards remaining and idle time; structured session report + optional JSON/Markdown checkpoints. |
+| 🔁 **Two backends, one interface** | Built-in Python client (Steam Guard / 2FA) **or** a local `steam-utility` install — with transparent fallback if one fails. |
+| ⚡ **Modern & tested** | `uv`-managed, fully typed, 242 tests across Python 3.12–3.14. |
 
 ---
 
-## 🚀 Quick Start
+## Quick start
 
 ```bash
 # 1. Install uv (if needed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 2. Clone and install
+# 2. Clone & install
 git clone https://github.com/bernardopg/steam-idler-python.git
 cd steam-idler-python
 uv sync
 
 # 3. Configure (never commit the filled .env)
 cp .env.example .env
-#    then edit .env: USERNAME, PASSWORD, and ideally STEAM_API_KEY
+#    edit .env → USERNAME, PASSWORD, and ideally STEAM_API_KEY
 
 # 4. Preview without contacting Steam
 ./run.sh --dry-run
 
-# 5. Run it (terminal) — or ./run-gui.sh for the desktop GUI
+# 5. Run it — terminal, or ./run-gui.sh for the desktop GUI
 ./run.sh
 ```
 
-> 💡 A free [Steam Web API key](https://steamcommunity.com/dev/apikey) unlocks automatic library sync and badge-based filtering. Without it the bot still runs, but can't filter as precisely.
+> 💡 A free [Steam Web API key](https://steamcommunity.com/dev/apikey) unlocks automatic
+> library sync and badge-based filtering. Without it the bot still runs — it just can't
+> filter as precisely.
 
 ---
 
-## 📦 Requirements
+## How it works
 
-- **Python 3.12+** (managed for you by `uv`)
+The orchestrator wires a configuration layer to a swappable idling backend and three card
+services, then drives a refresh loop that tracks drops as they drain.
+
+<p align="center">
+  <img src="docs/assets/architecture.svg" alt="Architecture: entry and config feed the SteamIdleBot orchestrator, which drives a swappable backend and three card services, with results tracked by IdleTracker" width="100%">
+</p>
+
+Game selection is a **funnel** — each stage narrows the set, capped at Steam's hard limit of 32:
+
+<p align="center">
+  <img src="docs/assets/pipeline.svg" alt="Pipeline: library source, then has-cards filter, then drops-remaining filter, then exclusions and cap to 32 games" width="100%">
+</p>
+
+---
+
+## Common commands
+
+```bash
+./run.sh                              # run normally (terminal)
+./run.sh --dry-run                    # print config + chosen games, no Steam contact
+./run.sh --no-trading-cards           # skip trading-card filtering
+./run.sh --max-games 10               # cap idled games
+./run.sh --refresh-interval-seconds 300   # re-run selection every 5 min
+./run.sh --checkpoint-minutes 5 --duration-minutes 25  # timed run + JSON/MD checkpoints
+./run.sh --stop-app-ids "570,730"     # stop steam-utility idles for those App IDs and exit
+./run-gui.sh                          # desktop GUI
+```
+
+Full flag and setting reference: **[USAGE guide](docs/en/USAGE.md)**.
+
+---
+
+## Configuration
+
+Settings come from environment variables / a `.env` file (copy `.env.example`). The two
+required values are `USERNAME` and `PASSWORD`; everything else has sane defaults.
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `STEAM_API_KEY` | — | Library sync + badge filtering *(recommended)* |
+| `IDLING_BACKEND` | `python` | `python` or `steam_utility` |
+| `MAX_GAMES_TO_IDLE` | `30` | Cap (Steam hard limit: 32) |
+| `REFRESH_INTERVAL_SECONDS` | `600` | How often the selection pipeline re-runs |
+| `CHECKPOINT_MINUTES` | `0` | Write JSON/MD checkpoints every N min (0 = off) |
+| `DURATION_MINUTES` | `0` | Stop after N min (0 = run until interrupted) |
+| `POST_RUN_VERIFY_SECONDS` | `0` | Re-scrape card counts N s after stopping |
+| `AUTO_BROWSER_COOKIES` | `true` | Recover a community session from a logged-in browser |
+
+> 🔐 Card-drop filtering needs an **authenticated `web:community` session**. See the
+> [authentication & accuracy guide](docs/en/README.md#-authentication--card-drop-accuracy).
+
+---
+
+## Documentation
+
+|                | 🇺🇸 English | 🇧🇷 Português (BR) |
+| -------------- | ----------- | ------------------ |
+| Full guide     | [README](docs/en/README.md) | [README](docs/pt-br/README.md) |
+| Command sheet  | [USAGE](docs/en/USAGE.md)   | [USAGE](docs/pt-br/USAGE.md)   |
+| Security       | [SECURITY](docs/en/SECURITY.md) | [SECURITY](docs/pt-br/SECURITY.md) |
+| Roadmap & backlog | [BACKLOG](BACKLOG.md) | [BACKLOG](BACKLOG.md) |
+
+---
+
+## Requirements
+
+- **Python 3.12+** — managed for you by `uv`
 - **A Steam account** with games that have trading cards
 - **Steam Web API key** *(recommended)* — library sync + badge data
-- **For drop filtering**: an authenticated Steam web session (see the [auth guide](docs/en/README.md#-authentication--card-drop-accuracy))
+- **For drop filtering** — an authenticated Steam web session
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-Contributions welcome in both languages. See the developer guides:
-[🇺🇸 English](docs/en/README.md#-developer-guide) · [🇧🇷 Português](docs/pt-br/README.md#-guia-do-desenvolvedor)
+Contributions welcome in both languages. Run `uv run ruff check . && uv run mypy src && uv run pytest -q`
+before opening a PR. See the developer guides:
+[🇺🇸 English](docs/en/README.md#-developer-guide) · [🇧🇷 Português](docs/pt-br/README.md#-guia-do-desenvolvedor).
+The prioritized roadmap lives in **[BACKLOG.md](BACKLOG.md)**.
 
-## 📄 License
+## License
 
 MIT — see [LICENSE](LICENSE). Not affiliated with Valve. Use responsibly and follow Steam's Terms of Service.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-All previously tracked items are done. See `CHANGELOG.md` for the delivered work
-and `CLAUDE.md` (Badge API behavior) for the documented card-drop data caveat.
+The full, prioritized backlog — epics, user stories, impact/effort, sprints and known
+risks — now lives in **[BACKLOG.md](BACKLOG.md)**.
 
-_No open items._
+Delivered work is recorded in [`CHANGELOG.md`](CHANGELOG.md).

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="700" viewBox="0 0 1120 700" role="img" aria-label="Steam Idle Bot architecture">
+  <defs>
+    <style>
+      .lbl{font-family:Segoe UI,Helvetica,Arial,sans-serif;}
+      .t{fill:#ffffff;font-weight:700;}
+      .s{fill:#c7d5e0;font-weight:500;}
+      .h{fill:#8aa0b2;font-weight:600;letter-spacing:1px;}
+    </style>
+    <marker id="arw" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0 0 L8 3 L0 6 z" fill="#66c0f4"/>
+    </marker>
+    <marker id="arwg" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0 0 L8 3 L0 6 z" fill="#a3cf06"/>
+    </marker>
+  </defs>
+
+  <rect width="1120" height="700" rx="16" fill="#0f1216"/>
+  <rect x="0" y="0" width="1120" height="5" fill="#66c0f4"/>
+  <text x="40" y="46" class="lbl t" font-size="26">Architecture</text>
+  <text x="40" y="70" class="lbl s" font-size="15">Entry → configuration → orchestrator → swappable backend + three card services → tracking</text>
+
+  <!-- Entry / Config -->
+  <g class="lbl">
+    <rect x="40" y="96" width="300" height="92" rx="12" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="58" y="124" class="h" font-size="12">ENTRY</text>
+    <text x="58" y="150" class="t" font-size="17">__main__ → main.main()</text>
+    <text x="58" y="174" class="s" font-size="13">parse args · choose CLI or GUI</text>
+
+    <rect x="372" y="96" width="300" height="92" rx="12" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="390" y="124" class="h" font-size="12">CONFIG</text>
+    <text x="390" y="150" class="t" font-size="17">Settings (Pydantic v2)</text>
+    <text x="390" y="174" class="s" font-size="13">env · .env · legacy config.py</text>
+
+    <rect x="704" y="96" width="376" height="92" rx="12" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="722" y="124" class="h" font-size="12">PRESENTATION</text>
+    <text x="722" y="150" class="t" font-size="17">Terminal panel · Tkinter GUI</text>
+    <text x="722" y="174" class="s" font-size="13">live status · session report · checkpoints</text>
+  </g>
+
+  <!-- Orchestrator -->
+  <g class="lbl">
+    <rect x="300" y="232" width="520" height="84" rx="12" fill="#16324a" stroke="#66c0f4" stroke-width="2"/>
+    <text x="560" y="262" text-anchor="middle" class="t" font-size="20">SteamIdleBot — orchestrator</text>
+    <text x="560" y="290" text-anchor="middle" class="s" font-size="13">run() → selection pipeline · refresh loop · reconnect · graceful stop</text>
+  </g>
+
+  <!-- Backends column -->
+  <g class="lbl">
+    <rect x="40" y="372" width="300" height="232" rx="12" fill="#15191f" stroke="#a3cf06"/>
+    <text x="58" y="400" class="h" font-size="12">IDLING BACKENDS (swappable)</text>
+
+    <rect x="60" y="416" width="260" height="76" rx="10" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="76" y="444" class="t" font-size="16">SteamClientWrapper</text>
+    <text x="76" y="466" class="s" font-size="12.5">python · steam lib · Guard/2FA</text>
+    <text x="76" y="484" class="s" font-size="12.5">builds authenticated web session</text>
+
+    <rect x="60" y="504" width="260" height="76" rx="10" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="76" y="532" class="t" font-size="16">SteamUtilityIdleClient</text>
+    <text x="76" y="554" class="s" font-size="12.5">steam_utility · subprocess bridge</text>
+    <text x="76" y="572" class="s" font-size="12.5">/proc idle reconciliation</text>
+
+    <path d="M190 492 L190 504" stroke="#a3cf06" stroke-width="2" stroke-dasharray="4 3" marker-end="url(#arwg)"/>
+    <text x="200" y="501" class="s" font-size="11">fallback</text>
+  </g>
+
+  <!-- Services column -->
+  <g class="lbl">
+    <rect x="372" y="372" width="708" height="232" rx="12" fill="#15191f" stroke="#66c0f4"/>
+    <text x="390" y="400" class="h" font-size="12">CARD SERVICES (degrade gracefully)</text>
+
+    <rect x="392" y="416" width="216" height="164" rx="10" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="500" y="446" text-anchor="middle" class="t" font-size="15">TradingCardDetector</text>
+    <text x="500" y="470" text-anchor="middle" class="s" font-size="12">does the game</text>
+    <text x="500" y="488" text-anchor="middle" class="s" font-size="12">have cards?</text>
+    <text x="500" y="516" text-anchor="middle" class="s" font-size="11.5">store scrape + JSON cache</text>
+
+    <rect x="624" y="416" width="216" height="164" rx="10" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="732" y="446" text-anchor="middle" class="t" font-size="15">BadgeService</text>
+    <text x="732" y="470" text-anchor="middle" class="s" font-size="12">cards-remaining</text>
+    <text x="732" y="488" text-anchor="middle" class="s" font-size="12">via Web API</text>
+    <text x="732" y="516" text-anchor="middle" class="s" font-size="11.5">needs STEAM_API_KEY</text>
+
+    <rect x="856" y="416" width="204" height="164" rx="10" fill="#1b2838" stroke="#3a6a8a"/>
+    <text x="958" y="446" text-anchor="middle" class="t" font-size="15">CardDropChecker</text>
+    <text x="958" y="470" text-anchor="middle" class="s" font-size="12">drops remaining</text>
+    <text x="958" y="488" text-anchor="middle" class="s" font-size="12">via scraping</text>
+    <text x="958" y="516" text-anchor="middle" class="s" font-size="11.5">no-drop cache · session verify</text>
+  </g>
+
+  <!-- Tracking -->
+  <g class="lbl">
+    <rect x="372" y="632" width="708" height="48" rx="10" fill="#16324a" stroke="#66c0f4"/>
+    <text x="726" y="662" text-anchor="middle" class="t" font-size="15">IdleTracker — before/after snapshots · drops · session report &amp; JSON checkpoints</text>
+  </g>
+
+  <!-- arrows -->
+  <g fill="none" stroke="#66c0f4" stroke-width="2">
+    <path d="M190 188 L190 232 L300 232" marker-end="url(#arw)"/>
+    <path d="M522 188 L522 232" marker-end="url(#arw)"/>
+    <path d="M820 254 L892 254 L892 188" marker-end="url(#arw)"/>
+    <path d="M360 316 L190 316 L190 372" marker-end="url(#arw)"/>
+    <path d="M620 316 L726 316 L726 372" marker-end="url(#arw)"/>
+    <path d="M726 604 L726 632" marker-end="url(#arw)"/>
+  </g>
+</svg>

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" viewBox="0 0 1200 320" role="img" aria-label="Steam Idle Bot — farm Steam playtime and trading-card drops on autopilot">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#171a21"/>
+      <stop offset="0.55" stop-color="#1b2838"/>
+      <stop offset="1" stop-color="#2a475e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#66c0f4"/>
+      <stop offset="1" stop-color="#a3cf06"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="6" flood-color="#000000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="320" rx="20" fill="url(#bg)"/>
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accent)"/>
+
+  <!-- trading cards motif -->
+  <g transform="translate(905,160)" filter="url(#soft)">
+    <g transform="rotate(-16)">
+      <rect x="-60" y="-94" width="150" height="210" rx="14" fill="#0e1116" stroke="#3a6a8a" stroke-width="2"/>
+    </g>
+    <g transform="rotate(-2)">
+      <rect x="-40" y="-100" width="150" height="210" rx="14" fill="#1b2838" stroke="#66c0f4" stroke-width="2"/>
+      <circle cx="35" cy="-55" r="26" fill="none" stroke="#66c0f4" stroke-width="3"/>
+      <path d="M35 -75 l6 14 15 1 -11 10 4 15 -14 -8 -14 8 4 -15 -11 -10 15 -1z" fill="#a3cf06"/>
+      <rect x="-12" y="-8" width="94" height="9" rx="4" fill="#2a475e"/>
+      <rect x="-12" y="12" width="70" height="8" rx="4" fill="#22384a"/>
+      <rect x="-12" y="30" width="84" height="8" rx="4" fill="#22384a"/>
+    </g>
+  </g>
+
+  <!-- title block -->
+  <g transform="translate(70,108)">
+    <g transform="translate(0,-34)">
+      <circle cx="22" cy="22" r="22" fill="#0e1116" stroke="url(#accent)" stroke-width="3"/>
+      <circle cx="22" cy="22" r="8" fill="#66c0f4"/>
+      <path d="M22 6 a16 16 0 0 1 14 8" fill="none" stroke="#a3cf06" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <text x="62" y="-2" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="58" font-weight="800" fill="#ffffff">Steam Idle Bot</text>
+    <text x="64" y="42" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="25" font-weight="500" fill="#c7d5e0">Farm playtime &amp; trading-card drops — on autopilot.</text>
+  </g>
+
+  <!-- feature chips -->
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="18" font-weight="600">
+    <g transform="translate(72,196)">
+      <rect width="232" height="42" rx="21" fill="#0e1116" stroke="#66c0f4" stroke-width="1.5"/>
+      <text x="116" y="27" text-anchor="middle" fill="#66c0f4">Drops only where it matters</text>
+    </g>
+    <g transform="translate(320,196)">
+      <rect width="170" height="42" rx="21" fill="#0e1116" stroke="#a3cf06" stroke-width="1.5"/>
+      <text x="85" y="27" text-anchor="middle" fill="#a3cf06">Learns over time</text>
+    </g>
+    <g transform="translate(506,196)">
+      <rect width="196" height="42" rx="21" fill="#0e1116" stroke="#c7d5e0" stroke-width="1.5"/>
+      <text x="98" y="27" text-anchor="middle" fill="#c7d5e0">Two idling backends</text>
+    </g>
+  </g>
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#8aa0b2">
+    <text x="72" y="276">Python 3.12+ · uv-managed · 242 tests · MIT</text>
+  </g>
+</svg>

--- a/docs/assets/pipeline.svg
+++ b/docs/assets/pipeline.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="340" viewBox="0 0 1120 340" role="img" aria-label="Game selection pipeline">
+  <defs>
+    <style>
+      .lbl{font-family:Segoe UI,Helvetica,Arial,sans-serif;}
+      .t{fill:#ffffff;font-weight:700;}
+      .s{fill:#c7d5e0;font-weight:500;}
+      .n{fill:#a3cf06;font-weight:700;}
+      .h{fill:#8aa0b2;font-weight:600;letter-spacing:1px;}
+    </style>
+    <marker id="f" markerWidth="12" markerHeight="12" refX="7" refY="4" orient="auto">
+      <path d="M0 0 L8 4 L0 8 z" fill="#66c0f4"/>
+    </marker>
+    <linearGradient id="fun" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2a475e"/>
+      <stop offset="1" stop-color="#16324a"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1120" height="340" rx="16" fill="#0f1216"/>
+  <rect x="0" y="0" width="1120" height="5" fill="#a3cf06"/>
+  <text x="40" y="44" class="lbl t" font-size="24">Game selection pipeline</text>
+  <text x="40" y="68" class="lbl s" font-size="14">GameManager.get_games_to_idle() — applied in order, narrowing the set each stage</text>
+
+  <!-- funnel band -->
+  <path d="M40 110 L1080 110 L1010 240 L110 240 Z" fill="url(#fun)" opacity="0.35"/>
+
+  <g class="lbl">
+    <!-- 1 Source -->
+    <rect x="48" y="118" width="206" height="114" rx="12" fill="#1b2838" stroke="#66c0f4" stroke-width="2"/>
+    <text x="66" y="146" class="h" font-size="12">1 · SOURCE</text>
+    <text x="66" y="172" class="t" font-size="16">Library</text>
+    <text x="66" y="194" class="s" font-size="12">owned games (Web API or</text>
+    <text x="66" y="211" class="s" font-size="12">steam_utility) · or manual IDs</text>
+
+    <!-- 2 Has cards -->
+    <rect x="286" y="118" width="206" height="114" rx="12" fill="#1b2838" stroke="#66c0f4" stroke-width="2"/>
+    <text x="304" y="146" class="h" font-size="12">2 · HAS CARDS</text>
+    <text x="304" y="172" class="t" font-size="16">filter_trading_cards</text>
+    <text x="304" y="194" class="s" font-size="12">BadgeService catalog,</text>
+    <text x="304" y="211" class="s" font-size="12">else store-page detect</text>
+
+    <!-- 3 Drops remaining -->
+    <rect x="524" y="118" width="206" height="114" rx="12" fill="#1b2838" stroke="#66c0f4" stroke-width="2"/>
+    <text x="542" y="146" class="h" font-size="12">3 · DROPS LEFT</text>
+    <text x="542" y="172" class="t" font-size="16">completed drops out</text>
+    <text x="542" y="194" class="s" font-size="12">API badges → scrape;</text>
+    <text x="542" y="211" class="s" font-size="12">no-drop cache skips farmed</text>
+
+    <!-- 4 Exclude + cap -->
+    <rect x="762" y="118" width="206" height="114" rx="12" fill="#1b2838" stroke="#66c0f4" stroke-width="2"/>
+    <text x="780" y="146" class="h" font-size="12">4 · EXCLUDE + CAP</text>
+    <text x="780" y="172" class="t" font-size="16">EXCLUDE_APP_IDS</text>
+    <text x="780" y="194" class="s" font-size="12">drop excluded, then</text>
+    <text x="780" y="211" class="s" font-size="12">truncate to max_games</text>
+
+    <!-- result -->
+    <rect x="1000" y="138" width="74" height="74" rx="37" fill="#16324a" stroke="#a3cf06" stroke-width="2"/>
+    <text x="1037" y="172" text-anchor="middle" class="n" font-size="22">≤ 32</text>
+    <text x="1037" y="194" text-anchor="middle" class="s" font-size="11">idled</text>
+  </g>
+
+  <g fill="none" stroke="#66c0f4" stroke-width="2.5">
+    <path d="M256 175 L284 175" marker-end="url(#f)"/>
+    <path d="M494 175 L522 175" marker-end="url(#f)"/>
+    <path d="M732 175 L760 175" marker-end="url(#f)"/>
+    <path d="M970 175 L998 175" marker-end="url(#f)"/>
+  </g>
+
+  <g class="lbl s" font-size="13" fill="#8aa0b2">
+    <text x="40" y="288">Steam hard limit: 32 simultaneous games. Authenticated web session pushed into the scrapers; positive verdicts are never cached.</text>
+    <text x="40" y="312">Re-runs every REFRESH_INTERVAL_SECONDS (default 600s) so the set tracks drops draining in real time.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## README novo + backlog scrum completo

Docs-only. Sem código tocado (242 testes inalterados).

### README.md — reescrito do zero
- **Banner SVG de capa** no topo (`docs/assets/banner.svg`).
- Tabela **"Why it's different"** — objetivo, vendável, conciso.
- **2 schemas SVG** ilustrando a lógica:
  - `architecture.svg` — entry/config → orquestrador `SteamIdleBot` → backend swappable + 3 serviços de carta → `IdleTracker`.
  - `pipeline.svg` — funil de seleção (source → has-cards → drops-left → exclude/cap ≤32).
- Quick start, cheat-sheet de comandos, tabela de configuração, links de docs (EN/PT-BR) + backlog.

### BACKLOG.md — padrão da indústria, scrum
- Legenda: status (✅🟡⬜🧊), tipo, **impacto** (🟥🟧🟩), **esforço** (S/M/L), **prioridade** (P0–P3 = impacto÷esforço).
- **Definition of Done** + cadência de sprints.
- **Shipped sprints 1–5** (PRs #30–#34) com checkmarks.
- **Product backlog** por épico (A–I): reliability, accuracy, backends, UX, observability, packaging, quality, security, docs.
- **Known defects/risks** (R1–R4) + **next-sprint candidate** groomed.

### Outros
- `TODO.md` agora aponta pro `BACKLOG.md`.
- 3 SVGs self-contained, XML validado, renderizam em tema claro/escuro.
