### PR TITLE
feat(docs): GitHub Pages site impressionante + workflow build/deploy robusto

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,53 +1,86 @@
-# Simple workflow for deploying static content to GitHub Pages
+# Build and deploy the documentation site to GitHub Pages.
 name: Deploy docs to Pages
 
 on:
-  # Deploy docs on pushes to main that touch docs/ or the workflow itself.
-  # Pages deployment targets the protected `github-pages` environment, which only
-  # permits `main`, so this must NOT run on pull requests (it would fail instantly).
+  # On pushes to main, build AND deploy. On pull requests, only build (validation):
+  # the protected github-pages environment permits `main` only, so the deploy job
+  # is skipped on PRs while the build job still catches broken layouts/assets.
   push:
     branches: ["main"]
     paths:
       - "docs/**"
       - ".github/workflows/static.yml"
-  # Allows you to run this workflow manually from the Actions tab
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/static.yml"
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Least privilege: only the deploy job needs pages/id-token.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# One deployment at a time; let in-flight production deploys finish.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build docs (Jekyll) and deploy
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # ---- Build the static site and validate the output ----
+  build:
+    name: Build site
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
       - name: Build site with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
           source: ./docs
           destination: ./_site
+
+      - name: Validate build output
+        run: |
+          set -euo pipefail
+          test -f ./_site/index.html || { echo "::error::index.html missing from build"; exit 1; }
+          for asset in banner.svg architecture.svg pipeline.svg css/style.css; do
+            test -f "./_site/assets/$asset" || { echo "::error::missing asset: $asset"; exit 1; }
+          done
+          pages=$(find ./_site -name '*.html' | wc -l)
+          size=$(du -sh ./_site | cut -f1)
+          {
+            echo "### 📄 Docs site built"
+            echo ""
+            echo "- **HTML pages:** $pages"
+            echo "- **Total size:** $size"
+            echo "- **Assets verified:** banner · architecture · pipeline · stylesheet"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "./_site"
+
+  # ---- Deploy the built artifact to GitHub Pages (main only) ----
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        if: github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,9 +1,23 @@
-title: Steam Idle Bot Docs
+title: Steam Idle Bot
+description: Farm Steam playtime and trading-card drops on autopilot.
 markdown: kramdown
 theme: null
 baseurl: ""
 url: "https://idler.bebitterbebetter.com.br"
+
+# Default chrome for content pages (index.md overrides to the home layout).
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
 exclude:
+  # Stray duplicates kept only for the repo, not the built site.
+  - README.md
+  - USAGE.md
+  - idle-test-2026-06-23.md
+  # Never source application code into the site.
   - ../.github
   - ../tests
   - ../src

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,0 +1,27 @@
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <strong>Steam Idle Bot</strong> · MIT · not affiliated with Valve.
+    </div>
+    <div class="badge-row">
+      <span class="badge">Python 3.12+</span>
+      <span class="badge">242 tests</span>
+      <a class="badge" href="https://github.com/bernardopg/steam-idler-python">⭐ Star on GitHub</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  (function () {
+    var key = 'theme-preference';
+    var root = document.documentElement;
+    var get = function () { return localStorage.getItem(key) || 'auto'; };
+    var apply = function (m) { m === 'auto' ? root.removeAttribute('data-theme') : root.setAttribute('data-theme', m); };
+    apply(get());
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.addEventListener('click', function () {
+      var c = get(); var n = c === 'dark' ? 'light' : c === 'light' ? 'auto' : 'dark';
+      localStorage.setItem(key, n); apply(n);
+    });
+  })();
+</script>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,0 +1,12 @@
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{{ page.title | default: site.title }}</title>
+<meta name="description" content="{{ page.description | default: 'Farm Steam playtime and trading-card drops on autopilot — accurate, self-pruning, fully tested.' }}" />
+<meta name="color-scheme" content="dark light" />
+<meta name="theme-color" content="#0b0f14" />
+<meta property="og:title" content="{{ page.title | default: site.title }}" />
+<meta property="og:description" content="Farm Steam playtime and trading-card drops on autopilot." />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="{{ '/assets/banner.svg' | relative_url }}" />
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='%230b0f14'/><circle cx='16' cy='16' r='6' fill='none' stroke='%2366c0f4' stroke-width='3'/><circle cx='16' cy='16' r='2' fill='%23a3cf06'/></svg>" />
+<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,0 +1,14 @@
+<header>
+  <div class="container nav">
+    <div class="brand">
+      <span class="logo">●</span>
+      <a href="{{ '/' | relative_url }}">Steam Idle Bot</a>
+    </div>
+    <nav class="nav-links">
+      <a href="{{ '/en/README.html' | relative_url }}">English</a>
+      <a href="{{ '/pt-br/README.html' | relative_url }}">Português</a>
+      <a class="keep" href="https://github.com/bernardopg/steam-idler-python" target="_blank" rel="noopener">GitHub</a>
+      <button class="toggle keep" id="theme-toggle" aria-label="Toggle theme">🌗</button>
+    </nav>
+  </div>
+</header>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,80 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{{ page.title | default: site.title }}</title>
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
-  <meta name="color-scheme" content="dark light" />
+  {% include head.html %}
 </head>
-
 <body>
-  <header>
-    <div class="container nav">
-      <div class="brand">
-        <span class="logo">🎮</span>
-        <a href="{{ '/' | relative_url }}" style="text-decoration:none;color:inherit">Steam Idle Bot</a>
-      </div>
-      <div class="nav-links">
-        <a href="{{ '/' | relative_url }}">Home</a>
-        <a href="{{ '/en/README.html' | relative_url }}">English</a>
-        <a href="{{ '/pt-br/README.html' | relative_url }}">Português (BR)</a>
-        <a href="https://github.com/bernardopg/steam-idler-python" target="_blank" rel="noopener">GitHub</a>
-        <button class="toggle" id="theme-toggle" aria-label="Toggle theme">🌗 Theme</button>
-      </div>
-    </div>
-  </header>
-
-  <div class="container hero">
-    {% if page.title %}
-    <h1>{{ page.title }}</h1>
-    {% if page.description %}<p>{{ page.description }}</p>{% endif %}
-    {% else %}
-    <h1>Steam Idle Bot</h1>
-    <p class="muted">Automate Steam playtime farming and trading card drops.</p>
-    <div class="cta">
-      <a class="btn" href="{{ '/en/README.html' | relative_url }}">Get Started (EN)</a>
-      <a class="btn secondary" href="{{ '/pt-br/README.html' | relative_url }}">Começar (PT-BR)</a>
-    </div>
-    {% endif %}
-  </div>
+  {% include nav.html %}
 
   <div class="container">
-    <main>
+    <div class="doc-hero">
+      <h1>{{ page.title | default: site.title }}</h1>
+      {% if page.description %}<p class="muted">{{ page.description }}</p>{% endif %}
+    </div>
+    <main class="doc">
       <article>
         {{ content }}
       </article>
     </main>
-    <footer>
-      <div class="grid">
-        <div class="col-12">
-          <div class="badge-row">
-            <span class="badge">Python 3.9+</span>
-            <span class="badge">MIT License</span>
-            <a class="badge" href="https://github.com/bernardopg/steam-idler-python">⭐ Star on GitHub</a>
-          </div>
-        </div>
-      </div>
-    </footer>
   </div>
 
-  <script>
-    // Theme toggle with localStorage
-    const key = 'theme-preference';
-    const getPref = () => localStorage.getItem(key) || 'auto';
-    const apply = (mode) => {
-      if (mode === 'auto') document.documentElement.removeAttribute('data-theme');
-      else document.documentElement.setAttribute('data-theme', mode);
-    };
-    const setPref = (mode) => { localStorage.setItem(key, mode); apply(mode); };
-    apply(getPref());
-    document.getElementById('theme-toggle')?.addEventListener('click', () => {
-      const curr = getPref();
-      const next = curr === 'dark' ? 'light' : curr === 'light' ? 'auto' : 'dark';
-      setPref(next);
-    });
-  </script>
+  {% include footer.html %}
 </body>
-
 </html>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include head.html %}
+</head>
+<body>
+  {% include nav.html %}
+
+  <div class="container">
+    <!-- Hero -->
+    <div class="hero">
+      <img class="hero-banner" src="{{ '/assets/banner.svg' | relative_url }}" alt="Steam Idle Bot" />
+      <h1>Farm playtime &amp; trading-card drops — on autopilot</h1>
+      <p class="lede">
+        Steam Idle Bot syncs your library, idles <strong>only</strong> the games that still have
+        cards to drop, and remembers what's finished — so every run scans less and starts faster.
+      </p>
+      <div class="cta">
+        <a class="btn" href="{{ '/en/README.html' | relative_url }}">🚀 Get Started</a>
+        <a class="btn secondary" href="https://github.com/bernardopg/steam-idler-python">★ View on GitHub</a>
+      </div>
+      <div class="stat-row">
+        <span class="stat"><b>2</b> idling backends</span>
+        <span class="stat"><b>242</b> tests</span>
+        <span class="stat"><b>3.12–3.14</b> Python</span>
+        <span class="stat"><b>≤ 32</b> games / Steam limit</span>
+        <span class="stat"><b>MIT</b> licensed</span>
+      </div>
+    </div>
+
+    <!-- Features -->
+    <section>
+      <div class="section-head">
+        <span class="eyebrow">Why it's different</span>
+        <h2>Accurate, self-pruning, and readable</h2>
+        <p>Most idlers blindly run every game forever. This one knows where the drops are.</p>
+      </div>
+      <div class="features">
+        <div class="card reveal"><div class="ic">🎴</div><h3>Drops only where it matters</h3><p>Detects which games have trading cards and how many drops remain — idles just those, never wasting a slot.</p></div>
+        <div class="card reveal"><div class="ic">🧠</div><h3>Learns over time</h3><p>A persistent no-drop cache records fully-farmed games and skips them forever. Each run scans less.</p></div>
+        <div class="card reveal"><div class="ic">🔐</div><h3>Accurate by design</h3><p>Verifies the Steam web session is genuinely logged in, and auto-recovers a valid session from your browser.</p></div>
+        <div class="card reveal"><div class="ic">🖥️</div><h3>Readable output</h3><p>Live panel of game names, cards remaining and idle time; structured report + JSON/Markdown checkpoints.</p></div>
+        <div class="card reveal"><div class="ic">🔁</div><h3>Two backends, one interface</h3><p>Built-in Python client (Guard / 2FA) or a local <code>steam-utility</code> install — with transparent fallback.</p></div>
+        <div class="card reveal"><div class="ic">⚡</div><h3>Modern &amp; tested</h3><p><code>uv</code>-managed, fully typed, 242 tests across Python 3.12–3.14. Green on every push.</p></div>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section>
+      <div class="section-head">
+        <span class="eyebrow">How it works</span>
+        <h2>Architecture &amp; selection pipeline</h2>
+        <p>An orchestrator drives a swappable backend and three card services; game selection is a funnel.</p>
+      </div>
+      <figure class="figure">
+        <img src="{{ '/assets/architecture.svg' | relative_url }}" alt="System architecture diagram" />
+        <figcaption>Entry &amp; config → <strong>SteamIdleBot</strong> orchestrator → swappable backend + three card services → IdleTracker.</figcaption>
+      </figure>
+      <figure class="figure">
+        <img src="{{ '/assets/pipeline.svg' | relative_url }}" alt="Game selection pipeline diagram" />
+        <figcaption>Library → has-cards → drops-remaining → exclusions &amp; cap. Narrows to ≤ 32 idled games.</figcaption>
+      </figure>
+    </section>
+
+    <!-- Quick start -->
+    <section>
+      <div class="section-head">
+        <span class="eyebrow">Quick start</span>
+        <h2>Running in under a minute</h2>
+      </div>
+      <div class="codeblock">
+        <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span></div>
+<pre><code><span class="cm"># install uv, clone &amp; sync</span>
+curl -LsSf https://astral.sh/uv/install.sh | sh
+git clone https://github.com/bernardopg/steam-idler-python.git
+cd steam-idler-python && uv sync
+
+<span class="cm"># configure (never commit the filled .env)</span>
+cp .env.example .env   <span class="cm"># set USERNAME, PASSWORD, STEAM_API_KEY</span>
+
+<span class="ac">./run.sh --dry-run</span>     <span class="cm"># preview, no Steam contact</span>
+<span class="ac">./run.sh</span>               <span class="cm"># go — or ./run-gui.sh for the GUI</span></code></pre>
+      </div>
+    </section>
+
+    <!-- Docs -->
+    <section>
+      <div class="section-head">
+        <span class="eyebrow">Documentation</span>
+        <h2>Read in your language</h2>
+      </div>
+      <div class="lang-grid">
+        <div class="lang-card">
+          <h3>🇺🇸 English</h3>
+          <a href="{{ '/en/README.html' | relative_url }}">Full guide →</a>
+          <a href="{{ '/en/USAGE.html' | relative_url }}">Command sheet →</a>
+          <a href="{{ '/en/SECURITY.html' | relative_url }}">Security →</a>
+        </div>
+        <div class="lang-card">
+          <h3>🇧🇷 Português (BR)</h3>
+          <a href="{{ '/pt-br/README.html' | relative_url }}">Guia completo →</a>
+          <a href="{{ '/pt-br/USAGE.html' | relative_url }}">Comandos →</a>
+          <a href="{{ '/pt-br/SECURITY.html' | relative_url }}">Segurança →</a>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  {% include footer.html %}
+</body>
+</html>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,230 +1,196 @@
+/* ===== Steam Idle Bot — docs site ===== */
 :root {
   --bg: #0b0f14;
-  --surface: #11161d;
+  --bg-2: #0e141c;
+  --surface: #121925;
+  --surface-2: #16202e;
   --text: #e6edf3;
   --muted: #9aa6b2;
-  --link: #61dafb;
-  --accent: #5ac8fa;
-  --border: #1f2630;
+  --link: #66c0f4;
+  --accent: #66c0f4;
+  --accent-2: #a3cf06;
+  --border: #1f2a38;
+  --shadow: 0 18px 50px rgba(0, 0, 0, .45);
+  --radius: 16px;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
-    --bg: #ffffff;
-    --surface: #f7f7f9;
-    --text: #0b0f14;
-    --muted: #5b6672;
-    --link: #0a84ff;
-    --accent: #007aff;
-    --border: #e5e7eb;
+    --bg: #f5f8fb;
+    --bg-2: #eef3f8;
+    --surface: #ffffff;
+    --surface-2: #f3f7fb;
+    --text: #0d1b2a;
+    --muted: #54667a;
+    --link: #1769aa;
+    --accent: #1b8bd0;
+    --accent-2: #6f9e08;
+    --border: #d8e2ec;
+    --shadow: 0 16px 40px rgba(20, 50, 80, .12);
   }
 }
-
-/* Light/dark override via [data-theme] */
 [data-theme="light"] {
-  --bg: #ffffff;
-  --surface: #f7f7f9;
-  --text: #0b0f14;
-  --muted: #5b6672;
-  --link: #0a84ff;
-  --accent: #007aff;
-  --border: #e5e7eb;
+  --bg: #f5f8fb;
+  --bg-2: #eef3f8;
+  --surface: #ffffff;
+  --surface-2: #f3f7fb;
+  --text: #0d1b2a;
+  --muted: #54667a;
+  --link: #1769aa;
+  --accent: #1b8bd0;
+  --accent-2: #6f9e08;
+  --border: #d8e2ec;
+  --shadow: 0 16px 40px rgba(20, 50, 80, .12);
 }
-
 [data-theme="dark"] {
   --bg: #0b0f14;
-  --surface: #11161d;
+  --bg-2: #0e141c;
+  --surface: #121925;
+  --surface-2: #16202e;
   --text: #e6edf3;
   --muted: #9aa6b2;
-  --link: #61dafb;
-  --accent: #5ac8fa;
-  --border: #1f2630;
+  --link: #66c0f4;
+  --accent: #66c0f4;
+  --accent-2: #a3cf06;
+  --border: #1f2a38;
+  --shadow: 0 18px 50px rgba(0, 0, 0, .45);
 }
 
-* {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  height: 100%;
-}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Noto Sans", Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: "Segoe UI", system-ui, -apple-system, Helvetica, Arial, sans-serif;
   color: var(--text);
-  background: radial-gradient(1200px 600px at 50% -200px, rgba(90, 200, 250, 0.15), transparent), var(--bg);
-  line-height: 1.7;
+  background:
+    radial-gradient(1100px 540px at 12% -8%, rgba(102, 192, 244, .14), transparent 60%),
+    radial-gradient(900px 500px at 100% 0%, rgba(163, 207, 6, .10), transparent 55%),
+    var(--bg);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
 }
 
-.container {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 1rem;
-}
+a { color: var(--link); }
+.container { max-width: 1080px; margin: 0 auto; padding: 0 1.25rem; }
 
+/* ===== Header / nav ===== */
 header {
-  position: sticky;
-  top: 0;
-  backdrop-filter: saturate(180%) blur(8px);
-  background: color-mix(in oklab, var(--bg) 88%, transparent);
+  position: sticky; top: 0; z-index: 50;
+  backdrop-filter: saturate(160%) blur(10px);
+  background: color-mix(in oklab, var(--bg) 80%, transparent);
   border-bottom: 1px solid var(--border);
 }
-
-.nav {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 64px;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: .6rem;
-  font-weight: 700;
-}
-
+.nav { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.brand { display: flex; align-items: center; gap: .6rem; font-weight: 800; letter-spacing: .2px; }
+.brand a { color: inherit; text-decoration: none; }
 .brand .logo {
-  font-size: 1.35rem;
+  width: 30px; height: 30px; display: grid; place-items: center;
+  border-radius: 9px; background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #06121c; font-size: 1rem;
 }
-
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.nav a {
-  color: var(--text);
-  text-decoration: none;
-  opacity: .9;
-}
-
-.nav a:hover {
-  opacity: 1;
-}
-
+.nav-links { display: flex; align-items: center; gap: 1.1rem; }
+.nav-links a { color: var(--text); text-decoration: none; opacity: .85; font-weight: 600; font-size: .95rem; }
+.nav-links a:hover { opacity: 1; color: var(--accent); }
 .toggle {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text);
-  padding: .4rem .6rem;
-  border-radius: 8px;
-  cursor: pointer;
+  background: var(--surface); border: 1px solid var(--border); color: var(--text);
+  padding: .4rem .65rem; border-radius: 9px; cursor: pointer; font-size: .85rem;
 }
+.toggle:hover { border-color: var(--accent); }
+@media (max-width: 680px) { .nav-links a:not(.keep) { display: none; } }
 
-.hero {
-  padding: 3rem 0 2rem;
+/* ===== Hero ===== */
+.hero { padding: 3.4rem 0 1rem; text-align: center; }
+.hero-banner {
+  display: block; width: 100%; max-width: 1000px; margin: 0 auto;
+  border-radius: var(--radius); box-shadow: var(--shadow);
+  animation: rise .7s ease both;
 }
-
-.hero h1 {
-  font-size: clamp(1.8rem, 2.5vw + 1rem, 2.6rem);
-  margin: 0 0 .5rem;
-}
-
-.hero p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.cta {
-  display: flex;
-  gap: .75rem;
-  margin-top: 1.25rem;
-  flex-wrap: wrap;
-}
-
+.hero h1 { font-size: clamp(2rem, 3.2vw + 1rem, 3.1rem); margin: 1.6rem 0 .4rem; font-weight: 800; }
+.hero .lede { color: var(--muted); font-size: 1.15rem; max-width: 720px; margin: 0 auto; }
+.cta { display: flex; gap: .8rem; justify-content: center; margin-top: 1.6rem; flex-wrap: wrap; }
 .btn {
-  display: inline-flex;
-  align-items: center;
-  gap: .5rem;
-  background: var(--accent);
-  color: white;
-  border: none;
-  border-radius: 10px;
-  padding: .6rem .9rem;
-  text-decoration: none;
-  font-weight: 600;
+  display: inline-flex; align-items: center; gap: .5rem; text-decoration: none; font-weight: 700;
+  padding: .7rem 1.15rem; border-radius: 12px; border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #06121c;
+  transition: transform .15s ease, box-shadow .15s ease;
 }
+.btn:hover { transform: translateY(-2px); box-shadow: 0 10px 26px rgba(102, 192, 244, .35); }
+.btn.secondary { background: var(--surface); color: var(--text); border-color: var(--border); }
+.btn.secondary:hover { border-color: var(--accent); box-shadow: none; }
+.stat-row { display: flex; gap: .6rem; justify-content: center; flex-wrap: wrap; margin: 1.6rem 0 .5rem; }
+.stat { background: var(--surface); border: 1px solid var(--border); border-radius: 999px; padding: .35rem .85rem; font-size: .85rem; color: var(--muted); font-weight: 600; }
+.stat b { color: var(--text); }
 
-.btn.secondary {
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--border);
-}
+/* ===== Sections ===== */
+section { padding: 2.6rem 0; }
+.section-head { text-align: center; margin-bottom: 1.8rem; }
+.section-head h2 { font-size: clamp(1.4rem, 1.6vw + 1rem, 2rem); margin: 0 0 .35rem; }
+.section-head p { color: var(--muted); margin: 0; }
+.eyebrow { text-transform: uppercase; letter-spacing: 2px; font-size: .75rem; font-weight: 700; color: var(--accent); display: block; margin-bottom: .5rem; }
 
-main {
-  padding: 1rem 0 3rem;
+/* feature grid */
+.features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+.card {
+  background: linear-gradient(180deg, var(--surface), var(--surface-2));
+  border: 1px solid var(--border); border-radius: var(--radius); padding: 1.3rem;
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
 }
+.card:hover { transform: translateY(-4px); border-color: var(--accent); box-shadow: var(--shadow); }
+.card .ic { font-size: 1.6rem; display: inline-grid; place-items: center; margin-bottom: .5rem; }
+.card h3 { margin: .2rem 0 .4rem; font-size: 1.1rem; }
+.card p { margin: 0; color: var(--muted); font-size: .96rem; }
+@media (max-width: 880px) { .features { grid-template-columns: 1fr; } }
 
-article {
-  background: color-mix(in oklab, var(--surface) 92%, transparent);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1.2rem;
+/* diagram frame */
+.figure {
+  background: linear-gradient(180deg, var(--surface), var(--surface-2));
+  border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 1rem; box-shadow: var(--shadow); margin: 0 0 1.2rem;
 }
+.figure img { display: block; width: 100%; border-radius: 10px; }
+.figure figcaption { color: var(--muted); font-size: .9rem; text-align: center; margin-top: .7rem; }
 
-pre {
-  background: #0d1117;
-  color: #c9d1d9;
-  padding: 1rem;
-  border-radius: 10px;
-  overflow: auto;
-}
+/* code block */
+.codeblock { background: #0a0e14; border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
+.codeblock .bar { display: flex; gap: .5rem; padding: .7rem .9rem; border-bottom: 1px solid var(--border); }
+.codeblock .dot { width: 11px; height: 11px; border-radius: 50%; }
+.codeblock .dot.r { background: #ff5f56; } .codeblock .dot.y { background: #ffbd2e; } .codeblock .dot.g { background: #27c93f; }
+.codeblock pre { margin: 0; padding: 1.1rem 1.2rem; overflow: auto; }
+.codeblock code { background: none; color: #d7e3ee; font-family: "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace; font-size: .9rem; line-height: 1.75; }
+.codeblock .cm { color: #6b8299; } .codeblock .ac { color: var(--accent-2); }
 
-code {
-  background: color-mix(in oklab, var(--surface) 92%, transparent);
-  padding: .1rem .3rem;
-  border-radius: 6px;
-}
+/* lang cards */
+.lang-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.lang-card { background: linear-gradient(180deg, var(--surface), var(--surface-2)); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.3rem; }
+.lang-card h3 { margin: 0 0 .6rem; }
+.lang-card a { display: inline-block; margin: .2rem .5rem .2rem 0; font-weight: 600; }
+@media (max-width: 720px) { .lang-grid { grid-template-columns: 1fr; } }
 
-footer {
-  border-top: 1px solid var(--border);
-  padding: 1rem 0;
-  color: var(--muted);
-}
+/* ===== Doc-page article ===== */
+.doc-hero { padding: 2.6rem 0 .5rem; }
+.doc-hero h1 { font-size: clamp(1.7rem, 2.4vw + 1rem, 2.4rem); margin: 0 0 .4rem; }
+.doc-hero .muted { color: var(--muted); margin: 0; }
+main.doc { padding: 1rem 0 3rem; }
+article { background: linear-gradient(180deg, var(--surface), var(--surface-2)); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.6rem 1.8rem; box-shadow: var(--shadow); }
+article h1, article h2, article h3 { line-height: 1.3; }
+article h2 { margin-top: 1.8rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+article a { text-decoration: none; } article a:hover { text-decoration: underline; }
+article pre { background: #0a0e14; color: #d7e3ee; padding: 1rem 1.1rem; border-radius: 12px; overflow: auto; border: 1px solid var(--border); }
+article code { background: color-mix(in oklab, var(--surface) 80%, transparent); padding: .12rem .38rem; border-radius: 6px; font-size: .9em; }
+article pre code { background: none; padding: 0; }
+article table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+article th, article td { border: 1px solid var(--border); padding: .55rem .7rem; text-align: left; }
+article th { background: var(--surface-2); }
+article blockquote { margin: 1rem 0; padding: .6rem 1rem; border-left: 3px solid var(--accent); background: var(--surface-2); border-radius: 0 10px 10px 0; color: var(--muted); }
 
-footer a {
-  color: var(--link);
-  text-decoration: none;
-}
+/* ===== Footer ===== */
+footer { border-top: 1px solid var(--border); padding: 2rem 0; margin-top: 2rem; color: var(--muted); }
+.footer-inner { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.badge-row { display: flex; gap: .55rem; flex-wrap: wrap; }
+.badge { display: inline-flex; align-items: center; gap: .35rem; font-size: .82rem; border: 1px solid var(--border); border-radius: 999px; padding: .28rem .7rem; color: var(--muted); text-decoration: none; }
+.badge:hover { border-color: var(--accent); color: var(--text); }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 1rem;
-}
-
-.col-12 {
-  grid-column: 1 / -1;
-}
-
-.col-6 {
-  grid-column: span 6;
-}
-
-@media (max-width: 720px) {
-  .col-6 {
-    grid-column: 1 / -1;
-  }
-}
-
-.badge-row {
-  display: flex;
-  gap: .6rem;
-  flex-wrap: wrap;
-  margin-top: .75rem;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: .4rem;
-  font-size: .85rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: .25rem .6rem;
-  color: var(--muted);
-}
+@keyframes rise { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
+.reveal { animation: rise .6s ease both; }
+@media (prefers-reduced-motion: reduce) { *, .hero-banner { animation: none !important; scroll-behavior: auto; } }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,5 @@
 ---
-layout: default
-title: Steam Idle Bot Docs
+layout: home
+title: Steam Idle Bot
+description: Farm Steam playtime and trading-card drops on autopilot — accurate, self-pruning, fully tested.
 ---
-
-## Steam Idle Bot Documentation
-
-Farm Steam playtime and trading-card drops on autopilot — accurately and efficiently.
-
-Choose your language:
-
-- 🇺🇸 English — [README](./en/README.md) · [Usage](./en/USAGE.md) · [Security](./en/SECURITY.md)
-- 🇧🇷 Português (Brasil) — [README](./pt-br/README.md) · [Uso](./pt-br/USAGE.md) · [Segurança](./pt-br/SECURITY.md)
-
-Or browse the repository on GitHub: [bernardopg/steam-idler-python](https://github.com/bernardopg/steam-idler-python)


### PR DESCRIPTION
## GitHub Pages — site impressionante + workflow robusto

### Site (visual)
- **Home layout novo**: hero com o banner SVG, grid de features (value-prop), diagramas `architecture` + `pipeline` embutidos em molduras, quick-start estilo terminal, cards de idioma (EN/PT-BR).
- **_includes** compartilhados (head/nav/footer): OG meta, favicon SVG inline, **theme toggle** 3-estados (auto/claro/escuro).
- **CSS reescrito**: design tokens, fundo em gradiente, glass cards, hover/reveal, grids responsivos, `prefers-reduced-motion`. Corrige bug de `}` soltos do CSS antigo.
- `_config.yml`: layout default pros docs; exclui duplicatas soltas (`README.md`/`USAGE.md`/idle-test).

### Workflow (perfeito)
- Split **build → deploy**, permissões least-privilege por job (`pages`/`id-token` só no deploy).
- Build **valida** `index.html` + assets obrigatórios e escreve **job summary** (páginas, tamanho).
- Roda em **PR** (validação do build) com **deploy gated** a não-PR (main) — environment protegido `github-pages` nunca é tocado por PR.

### Verificação
- `jekyll build` local: 8 páginas geradas, todas com nav/tema, assets presentes, soltos excluídos, 404 ok.
