### PR TITLE
fix(docs): resolve GitHub Pages 404s (baseurl)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,8 +2,10 @@ title: Steam Idle Bot
 description: Farm Steam playtime and trading-card drops on autopilot.
 markdown: kramdown
 theme: null
-baseurl: ""
-url: "https://idler.bebitterbebetter.com.br"
+# Project page: site is served under /steam-idler-python, so baseurl must match
+# or every `relative_url` asset (CSS, SVGs, doc links) 404s at the domain root.
+baseurl: "/steam-idler-python"
+url: "https://bernardopg.github.io"
 
 # Default chrome for content pages (index.md overrides to the home layout).
 defaults:


### PR DESCRIPTION
## Problem
Live site at `bernardopg.github.io/steam-idler-python/` rendered unstyled — `style.css`, `banner.svg`, `architecture.svg`, `pipeline.svg` all 404.

## Cause
`_config.yml` had `baseurl: ""`. Every asset uses `relative_url`, which prepends `site.baseurl`. With an empty baseurl on a **project page**, `/assets/css/style.css` resolved to `github.io/assets/...` (domain root) instead of `github.io/steam-idler-python/assets/...`.

The `url` pointed at a custom domain `idler.bebitterbebetter.com.br`, but its DNS resolves to `89.116.213.229 / 147.79.105.34` (not GitHub Pages' `185.199.108–111.153`) and Pages reports `cname: null` — so the custom domain was never active.

## Fix
`baseurl: "/steam-idler-python"`, `url: "https://bernardopg.github.io"`. Fixes CSS, all SVGs, nav, and doc links in one change (all go through `relative_url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)